### PR TITLE
Fix bar and corner-open unclickable under fullscreen+special workspace

### DIFF
--- a/modules/ii/bar/Bar.qml
+++ b/modules/ii/bar/Bar.qml
@@ -52,12 +52,39 @@ Scope {
                 }
                 property bool superShow: false
                 property bool mustShow: hoverRegion.containsMouse || superShow
+                property var thisMonitorData: HyprlandData.monitors.find(m => m.name === barRoot.screen?.name)
+                property bool monitorHasFullscreen: HyprlandData.workspaceById[thisMonitorData?.activeWorkspace?.id]?.hasfullscreen ?? false
+                property bool monitorHasSpecialOpen: (thisMonitorData?.specialWorkspace?.name ?? "") !== ""
                 exclusionMode: ExclusionMode.Ignore
                 exclusiveZone: (Config?.options.bar.autoHide.enable && (!mustShow || !Config?.options.bar.autoHide.pushWindows)) ? 0 : Appearance.sizes.baseBarHeight + (Config.options.bar.cornerStyle === 1 ? Appearance.sizes.hyprlandGapsOut : 0) + (Config.options.bar.cornerStyle === 2 ? -6 : 0)
                 WlrLayershell.namespace: "quickshell:bar"
+                // Overlay layer only while special workspace sits on top of a fullscreen window on this monitor,
+                // else Top layer so fullscreen apps cover the bar as normal (Hyprland buries Top layer under fullscreen+special).
+                WlrLayershell.layer: (monitorHasFullscreen && monitorHasSpecialOpen) ? WlrLayer.Overlay : WlrLayer.Top
                 implicitHeight: Appearance.sizes.barHeight + Appearance.rounding.screenRounding
+                // When Overlay-layer, bar shares a layer with the screen-corner click zones (ScreenCorners.qml)
+                // and same-layer overlap is resolved by stacking, not layer priority - bar was winning and
+                // swallowing the tiny corner-open hit rects. Carve them out of the bar's own mask so clicks
+                // reach the corners underneath. Only relevant on the edge the bar and corners share.
+                property bool cutOutCornerOpenZones: (monitorHasFullscreen && monitorHasSpecialOpen) && (Config.options.bar.bottom === Config.options.sidebar.cornerOpen.bottom)
+                property int cornerOpenCutWidth: cutOutCornerOpenZones ? Config.options.sidebar.cornerOpen.cornerRegionWidth : 0
+                property int cornerOpenCutHeight: cutOutCornerOpenZones ? Config.options.sidebar.cornerOpen.cornerRegionHeight : 0
                 mask: Region {
                     item: hoverMaskRegion
+                    Region {
+                        intersection: Intersection.Subtract
+                        x: 0
+                        y: Config.options.bar.bottom ? (barRoot.height - barRoot.cornerOpenCutHeight) : 0
+                        width: barRoot.cornerOpenCutWidth
+                        height: barRoot.cornerOpenCutHeight
+                    }
+                    Region {
+                        intersection: Intersection.Subtract
+                        x: barRoot.width - barRoot.cornerOpenCutWidth
+                        y: Config.options.bar.bottom ? (barRoot.height - barRoot.cornerOpenCutHeight) : 0
+                        width: barRoot.cornerOpenCutWidth
+                        height: barRoot.cornerOpenCutHeight
+                    }
                 }
                 color: "transparent"
 

--- a/modules/ii/screenCorners/ScreenCorners.qml
+++ b/modules/ii/screenCorners/ScreenCorners.qml
@@ -148,26 +148,30 @@ Scope {
             property list<HyprlandWorkspace> workspacesForMonitor: Hyprland.workspaces.values.filter(workspace => workspace.monitor && workspace.monitor.name == monitor.name)
             property var activeWorkspaceWithFullscreen: workspacesForMonitor.filter(workspace => ((workspace.toplevels.values.filter(window => window.wayland?.fullscreen)[0] != undefined) && workspace.active))[0]
             property bool fullscreen: activeWorkspaceWithFullscreen != undefined
+            // A special workspace open on top of the fullscreen window should bring corners back,
+            // same reasoning as the bar's layer fix: fullscreen only buries them when nothing else is above it.
+            property var thisMonitorData: HyprlandData.monitors.find(m => m.name === monitor.name)
+            property bool specialOpen: (thisMonitorData?.specialWorkspace?.name ?? "") !== ""
 
             CornerPanelWindow {
                 screen: modelData
                 corner: RoundCorner.CornerEnum.TopLeft
-                fullscreen: monitorScope.fullscreen
+                fullscreen: monitorScope.fullscreen && !monitorScope.specialOpen
             }
             CornerPanelWindow {
                 screen: modelData
                 corner: RoundCorner.CornerEnum.TopRight
-                fullscreen: monitorScope.fullscreen
+                fullscreen: monitorScope.fullscreen && !monitorScope.specialOpen
             }
             CornerPanelWindow {
                 screen: modelData
                 corner: RoundCorner.CornerEnum.BottomLeft
-                fullscreen: monitorScope.fullscreen
+                fullscreen: monitorScope.fullscreen && !monitorScope.specialOpen
             }
             CornerPanelWindow {
                 screen: modelData
                 corner: RoundCorner.CornerEnum.BottomRight
-                fullscreen: monitorScope.fullscreen
+                fullscreen: monitorScope.fullscreen && !monitorScope.specialOpen
             }
         }
     }


### PR DESCRIPTION
Hyprland renders fullscreen windows above the bar's Top layer-shell layer, and a special workspace opened on top buries it further, leaving the bar visible but unable to receive input.

- Bar.qml: switch to Overlay layer only while a special workspace is open over a fullscreen window on that monitor, detected via HyprlandData's monitor/workspace state.
- ScreenCorners.qml: same detection extends the corner-open hit zones (top-left/top-right sidebar toggles) past the existing fullscreen-hides-corners rule.
- Bar.qml: once bar and corners share the Overlay layer, same-layer overlap is resolved by stacking rather than layer priority, so the bar was swallowing the corner-open hit rects. Subtract those rects from the bar's own mask when on the same screen edge.