### PR TITLE
Add configurable network speed bar widget

### DIFF
--- a/modules/ii/bar/NetworkSpeed.qml
+++ b/modules/ii/bar/NetworkSpeed.qml
@@ -1,0 +1,165 @@
+import QtQuick
+import QtQuick.Layouts
+import Quickshell.Io
+import qs.modules.common
+import qs.modules.common.widgets
+
+MouseArea {
+    id: root
+
+    property bool vertical: false
+    property real downloadBytesPerSecond: 0
+    property real uploadBytesPerSecond: 0
+    property real downloadedBytes: 0
+    property real uploadedBytes: 0
+    property real previousReceivedBytes: -1
+    property real previousTransmittedBytes: -1
+    property double previousSampleTime: 0
+
+    implicitWidth: vertical ? 36 : speedColumn.implicitWidth + 8
+    implicitHeight: vertical ? speedColumn.implicitHeight + 6 : 32
+
+    hoverEnabled: !Config.options.bar.tooltips.clickToShow
+
+    function formatRate(rate, compact) {
+        const units = compact
+            ? ["B", "K", "M", "G"]
+            : ["B/s", "KB/s", "MB/s", "GB/s"]
+        let value = Math.max(0, Number(rate) || 0)
+        let unitIndex = 0
+
+        while (value >= 1024 && unitIndex < units.length - 1) {
+            value /= 1024
+            unitIndex++
+        }
+
+        const precision = unitIndex > 0 && value < 100 ? 1 : 0
+        return `${value.toFixed(precision)}${compact ? "" : " "}${units[unitIndex]}`
+    }
+
+    function updateRate(contents) {
+        let receivedBytes = 0
+        let transmittedBytes = 0
+        const lines = contents.split("\n")
+
+        for (const line of lines) {
+            const separator = line.indexOf(":")
+            if (separator < 0) continue
+
+            const interfaceName = line.slice(0, separator).trim()
+            if (!interfaceName || interfaceName === "lo") continue
+
+            const fields = line.slice(separator + 1).trim().split(/\s+/)
+            if (fields.length < 9) continue
+
+            const received = Number(fields[0])
+            const transmitted = Number(fields[8])
+            if (!Number.isFinite(received) || !Number.isFinite(transmitted)) continue
+
+            receivedBytes += received
+            transmittedBytes += transmitted
+        }
+
+        const sampleTime = Date.now()
+        if (previousSampleTime > 0 && sampleTime > previousSampleTime) {
+            const elapsedMilliseconds = sampleTime - previousSampleTime
+            const receivedDelta = receivedBytes >= previousReceivedBytes
+                ? receivedBytes - previousReceivedBytes
+                : 0
+            const transmittedDelta = transmittedBytes >= previousTransmittedBytes
+                ? transmittedBytes - previousTransmittedBytes
+                : 0
+
+            downloadBytesPerSecond = receivedDelta * 1000 / elapsedMilliseconds
+            uploadBytesPerSecond = transmittedDelta * 1000 / elapsedMilliseconds
+            downloadedBytes += receivedDelta
+            uploadedBytes += transmittedDelta
+        }
+
+        previousReceivedBytes = receivedBytes
+        previousTransmittedBytes = transmittedBytes
+        previousSampleTime = sampleTime
+    }
+
+    FileView {
+        id: networkStats
+        path: "/proc/net/dev"
+        printErrors: false
+        onLoaded: root.updateRate(text())
+    }
+
+    Timer {
+        interval: 1000
+        repeat: true
+        running: root.visible
+        onTriggered: networkStats.reload()
+    }
+
+    TextMetrics {
+        id: regularRateMetrics
+        text: "999.9 MB/s"
+        font.pixelSize: Appearance.font.pixelSize.smallest
+        font.weight: Font.Medium
+    }
+
+    component SpeedLine: RowLayout {
+        id: speedLine
+
+        required property string iconName
+        required property real rate
+        required property color accentColor
+
+        readonly property string rateText: root.formatRate(rate, root.vertical)
+
+        spacing: root.vertical ? 1 : 3
+
+        MaterialSymbol {
+            text: speedLine.iconName
+            iconSize: root.vertical
+                ? Appearance.font.pixelSize.smallest
+                : Appearance.font.pixelSize.smaller
+            color: speedLine.accentColor
+            opacity: speedLine.rate > 0 ? 1 : 0.45
+
+            Behavior on opacity {
+                animation: Appearance.animation.elementMoveFast.numberAnimation.createObject(this)
+            }
+        }
+
+        StyledText {
+            Layout.preferredWidth: root.vertical ? -1 : regularRateMetrics.width
+            horizontalAlignment: Text.AlignRight
+            text: speedLine.rateText
+            color: Appearance.colors.colOnLayer1
+            font.pixelSize: Appearance.font.pixelSize.smallest
+            font.weight: Font.Medium
+            font.features: { "tnum": 1 }
+        }
+    }
+
+    ColumnLayout {
+        id: speedColumn
+        anchors.centerIn: parent
+        spacing: -3
+
+        SpeedLine {
+            iconName: "arrow_upward"
+            rate: root.uploadBytesPerSecond
+            accentColor: Appearance.colors.colTertiary
+        }
+
+        SpeedLine {
+            iconName: "arrow_downward"
+            rate: root.downloadBytesPerSecond
+            accentColor: Appearance.colors.colPrimary
+        }
+    }
+
+    NetworkSpeedPopup {
+        hoverTarget: root
+        downloadSpeed: root.downloadBytesPerSecond
+        uploadSpeed: root.uploadBytesPerSecond
+        downloadedBytes: root.downloadedBytes
+        uploadedBytes: root.uploadedBytes
+    }
+}

--- a/modules/ii/bar/NetworkSpeedPopup.qml
+++ b/modules/ii/bar/NetworkSpeedPopup.qml
@@ -1,0 +1,247 @@
+import QtQuick
+import QtQuick.Layouts
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.services
+
+StyledPopup {
+    id: root
+
+    property real downloadSpeed: 0
+    property real uploadSpeed: 0
+    property real downloadedBytes: 0
+    property real uploadedBytes: 0
+
+    readonly property bool wifiConnected: Network.wifiStatus === "connected"
+    readonly property string connectionName: {
+        if (Network.ethernet)
+            return Network.networkName || Translation.tr("Ethernet")
+        if (wifiConnected)
+            return Network.active?.ssid || Network.networkName || Translation.tr("Wi-Fi")
+        return Translation.tr("Not connected")
+    }
+    readonly property string connectionDetails: {
+        if (Network.ethernet)
+            return Translation.tr("Ethernet · Connected")
+        if (wifiConnected) {
+            const strength = Network.networkStrength > 0
+                ? ` · ${Network.networkStrength}%`
+                : ""
+            return `${Translation.tr("Wi-Fi")}${strength}`
+        }
+        switch (Network.wifiStatus) {
+        case "connecting": return Translation.tr("Connecting")
+        case "limited": return Translation.tr("Limited connection")
+        case "disabled": return Translation.tr("Wi-Fi disabled")
+        default: return Translation.tr("Disconnected")
+        }
+    }
+
+    function formatRate(rate) {
+        return formatBytes(rate, "/s")
+    }
+
+    function formatTotal(bytes) {
+        return formatBytes(bytes, "")
+    }
+
+    function formatBytes(bytes, suffix) {
+        const units = ["B", "KB", "MB", "GB", "TB"]
+        let value = Math.max(0, Number(bytes) || 0)
+        let unitIndex = 0
+
+        while (value >= 1024 && unitIndex < units.length - 1) {
+            value /= 1024
+            unitIndex++
+        }
+
+        const precision = unitIndex > 0 && value < 100 ? 1 : 0
+        return `${value.toFixed(precision)} ${units[unitIndex]}${suffix}`
+    }
+
+    component SpeedCard: Rectangle {
+        id: card
+
+        required property string label
+        required property string iconName
+        required property real speed
+        required property real total
+        required property color accentColor
+
+        Layout.fillWidth: true
+        implicitWidth: 145
+        implicitHeight: cardContent.implicitHeight + 20
+        radius: Appearance.rounding.small
+        color: Appearance.colors.colSurfaceContainerHigh
+
+        ColumnLayout {
+            id: cardContent
+            anchors {
+                fill: parent
+                margins: 10
+            }
+            spacing: 1
+
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 4
+
+                MaterialSymbol {
+                    text: card.iconName
+                    iconSize: Appearance.font.pixelSize.normal
+                    color: card.accentColor
+                }
+
+                StyledText {
+                    text: card.label
+                    color: Appearance.colors.colOnSurfaceVariant
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    font.weight: Font.Medium
+                }
+
+                Item { Layout.fillWidth: true }
+            }
+
+            StyledText {
+                text: root.formatRate(card.speed)
+                color: Appearance.colors.colOnSurfaceVariant
+                font.pixelSize: Appearance.font.pixelSize.large
+                font.weight: Font.DemiBold
+                font.features: { "tnum": 1 }
+            }
+
+            StyledText {
+                text: `${root.formatTotal(card.total)} ${Translation.tr("this session")}`
+                color: Appearance.colors.colOnSurfaceVariant
+                opacity: 0.6
+                font.pixelSize: Appearance.font.pixelSize.smallest
+            }
+        }
+    }
+
+    ColumnLayout {
+        implicitWidth: 300
+        spacing: 10
+
+        RowLayout {
+            Layout.fillWidth: true
+            Layout.leftMargin: 3
+            Layout.rightMargin: 5
+            spacing: 7
+
+            MaterialShapeWrappedMaterialSymbol {
+                shape: MaterialShape.Shape.Circle
+                text: Network.materialSymbol
+                iconSize: Appearance.font.pixelSize.large
+                implicitSize: 36
+                color: Appearance.colors.colPrimaryContainer
+                colSymbol: Appearance.colors.colPrimary
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: -3
+
+                StyledText {
+                    text: root.connectionName
+                    font.pixelSize: Appearance.font.pixelSize.normal
+                    font.weight: Font.Medium
+                    color: Appearance.colors.colOnSurfaceVariant
+                    elide: Text.ElideRight
+                    Layout.fillWidth: true
+                }
+
+                StyledText {
+                    text: root.connectionDetails
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: Appearance.colors.colOnSurfaceVariant
+                    opacity: 0.6
+                }
+            }
+        }
+
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 6
+
+            SpeedCard {
+                label: Translation.tr("Upload")
+                iconName: "arrow_upward"
+                speed: root.uploadSpeed
+                total: root.uploadedBytes
+                accentColor: Appearance.colors.colTertiary
+            }
+
+            SpeedCard {
+                label: Translation.tr("Download")
+                iconName: "arrow_downward"
+                speed: root.downloadSpeed
+                total: root.downloadedBytes
+                accentColor: Appearance.colors.colPrimary
+            }
+        }
+
+        Rectangle {
+            readonly property bool hasDetails: Network.networkInterface !== ""
+                || Network.ipAddress !== ""
+                || Network.publicIpAddress !== ""
+                || Network.gateway !== ""
+                || Network.macAddress !== ""
+
+            visible: hasDetails
+            Layout.fillWidth: true
+            implicitHeight: visible ? detailsColumn.implicitHeight + 20 : 0
+            radius: Appearance.rounding.small
+            color: Appearance.colors.colSurfaceContainerHigh
+
+            ColumnLayout {
+                id: detailsColumn
+                anchors {
+                    fill: parent
+                    margins: 10
+                }
+                spacing: 4
+
+                StyledPopupValueRow {
+                    Layout.fillWidth: true
+                    visible: Network.networkInterface !== ""
+                    icon: "settings_ethernet"
+                    label: Translation.tr("Interface")
+                    value: Network.networkInterface
+                }
+
+                StyledPopupValueRow {
+                    Layout.fillWidth: true
+                    visible: Network.ipAddress !== ""
+                    icon: "lan"
+                    label: Translation.tr("Local IP")
+                    value: Network.ipAddress
+                }
+
+                StyledPopupValueRow {
+                    Layout.fillWidth: true
+                    visible: Network.publicIpAddress !== ""
+                    icon: "public"
+                    label: Translation.tr("Public IP")
+                    value: Network.publicIpAddress
+                }
+
+                StyledPopupValueRow {
+                    Layout.fillWidth: true
+                    visible: Network.gateway !== ""
+                    icon: "router"
+                    label: Translation.tr("Gateway")
+                    value: Network.gateway
+                }
+
+                StyledPopupValueRow {
+                    Layout.fillWidth: true
+                    visible: Network.macAddress !== ""
+                    icon: "fingerprint"
+                    label: Translation.tr("MAC address")
+                    value: Network.macAddress
+                }
+            }
+        }
+    }
+}

--- a/modules/ii/settings/pages/BarConfig.qml
+++ b/modules/ii/settings/pages/BarConfig.qml
@@ -42,6 +42,7 @@ ContentPage {
         { id: "media",             name: Translation.tr("Media"),                icon: "music_note" },
         { id: "resources",         name: Translation.tr("Resources"),            icon: "empty_dashboard" },
         { id: "systemIcons",       name: Translation.tr("System Icons"),         icon: "info" },
+        { id: "networkSpeed",      name: Translation.tr("Network Speed"),        icon: "network_check" },
         { id: "clockWidget",       name: Translation.tr("Clock"),                icon: "schedule" },
         { id: "utilButtons",       name: Translation.tr("Util Buttons"),         icon: "toggle_on" },
         { id: "sysTray",           name: Translation.tr("Tray"),                 icon: "inbox" },

--- a/services/Network.qml
+++ b/services/Network.qml
@@ -34,6 +34,11 @@ Singleton {
 
     property string networkName: ""
     property int networkStrength
+    property string networkInterface: ""
+    property string ipAddress: ""
+    property string publicIpAddress: ""
+    property string gateway: ""
+    property string macAddress: ""
     property string materialSymbol: root.ethernet
         ? "lan"
         : (root.wifiEnabled && root.wifiStatus === "connected")
@@ -158,6 +163,8 @@ Singleton {
         wifiStatusProcess.running = true
         updateNetworkName.running = true;
         updateNetworkStrength.running = true;
+        updateNetworkDetails.running = true;
+        updatePublicIp.running = true;
     }
 
     Process {
@@ -237,6 +244,55 @@ Singleton {
         stdout: SplitParser {
             onRead: data => {
                 root.networkStrength = parseInt(data);
+            }
+        }
+    }
+
+    Process {
+        id: updateNetworkDetails
+        running: true
+        command: ["sh", "-c", "device=$(nmcli -t -f DEVICE,TYPE,STATE device status | awk -F: '$3 == \"connected\" && $2 ~ /^(wifi|ethernet)$/ { print $1; exit }'); if [ -n \"$device\" ]; then nmcli -t -f GENERAL.DEVICE,GENERAL.HWADDR,IP4.ADDRESS,IP4.GATEWAY device show \"$device\"; fi"]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                let networkInterface = "";
+                let ipAddress = "";
+                let gateway = "";
+                let macAddress = "";
+
+                for (const line of text.trim().split("\n")) {
+                    const separator = line.indexOf(":");
+                    if (separator < 0) continue;
+
+                    const key = line.slice(0, separator);
+                    const value = line.slice(separator + 1);
+                    if (key === "GENERAL.DEVICE")
+                        networkInterface = value;
+                    else if (key === "GENERAL.HWADDR")
+                        macAddress = value;
+                    else if (key.startsWith("IP4.ADDRESS") && ipAddress === "")
+                        ipAddress = value.split("/")[0];
+                    else if (key === "IP4.GATEWAY")
+                        gateway = value;
+                }
+
+                root.networkInterface = networkInterface;
+                root.ipAddress = ipAddress;
+                root.gateway = gateway;
+                root.macAddress = macAddress;
+            }
+        }
+    }
+
+    Process {
+        id: updatePublicIp
+        running: true
+        command: ["curl", "-fsS", "--max-time", "5", "https://api.ipify.org"]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const candidate = text.trim();
+                root.publicIpAddress = /^[0-9a-fA-F:.]+$/.test(candidate)
+                    ? candidate
+                    : "";
             }
         }
     }


### PR DESCRIPTION
## Summary

- add a configurable Network Speed widget for the left, center, or right bar layout
- show upload above download with directional arrows and compact vertical-bar formatting
- add a matching hover popup with live rates, session totals, connection state, interface, local/public IP, gateway, and MAC address
- refresh NetworkManager connection details on connection changes and fetch the public IP with a bounded request

## Verification

- `qmllint` passes for the changed QML files
- Quickshell smoke-tested live upload/download sampling
- Quickshell instantiated the complete hover popup without QML errors
- local IP, public IP, gateway, and MAC population were exercised successfully

## Disclosure

This contribution was vibe-coded with AI assistance, then linted and smoke-tested.

Closes #14