### PR TITLE
Hide empty pinned dock section

### DIFF
--- a/modules/ii/dock/Dock.qml
+++ b/modules/ii/dock/Dock.qml
@@ -121,6 +121,7 @@ Scope {
                             anchors.horizontalCenter: parent.horizontalCenter
                             spacing: 3
                             property real padding: 5
+                            property bool hasPinnedApps: (Config.options?.dock.pinnedApps?.length ?? 0) > 0
 
                             VerticalButtonGroup {
                                 Layout.topMargin: 3
@@ -155,6 +156,7 @@ Scope {
 
                             DragApps {
                                 id: dragSlots
+                                visible: dockRow.hasPinnedApps
                                 Layout.fillHeight: true
                                 Layout.topMargin: 0
                                 Layout.leftMargin: Config.options.dock.showPinButton ? 0 : -15
@@ -166,7 +168,7 @@ Scope {
                             }
 
                             DockSeparator {
-                                visible: activeAppsArea.activeUnpinned.length > 0 || (Config.options.dock.showMedia && MprisController.activePlayer !== null)
+                                visible: dockRow.hasPinnedApps && (activeAppsArea.activeUnpinned.length > 0 || (Config.options.dock.showMedia && MprisController.activePlayer !== null))
                             }
 
                             Item {

--- a/modules/ii/dock/Dock.qml
+++ b/modules/ii/dock/Dock.qml
@@ -152,6 +152,8 @@ Scope {
 
                             DockSeparator {
                                 visible: Config.options.dock.showPinButton
+                                    && (dockRow.hasPinnedApps
+                                        || !(Config.options.dock.showMedia && dockMedia.hasTrack))
                             }
 
                             DragApps {


### PR DESCRIPTION
Hides the pinned section when there are no pinned apps. Once there are pinned apps it's shown again. 
<img width="589" height="66" alt="image" src="https://github.com/user-attachments/assets/e140c717-660a-4266-a57d-1c744718dbf0" />

without media player:
<img width="339" height="71" alt="image" src="https://github.com/user-attachments/assets/5fe0333d-02ff-48c8-8950-997f4535ac3c" />


Before:
<img width="245" height="74" alt="image" src="https://github.com/user-attachments/assets/c52a808d-338b-4c28-a5a9-ec8bb7b3bf12" />

