### PR TITLE
feat(record): improve screen recording UI, timer counter & parallel screenshot capture

### DIFF
--- a/modules/ii/bar/UtilButtons.qml
+++ b/modules/ii/bar/UtilButtons.qml
@@ -1,6 +1,7 @@
 import qs
 import qs.modules.common
 import qs.modules.common.widgets
+import qs.modules.common.functions
 import QtQuick
 import QtQuick.Layouts
 import Quickshell
@@ -113,7 +114,7 @@ Item {
                     anchors.verticalCenter: parent.verticalCenter
                     colBackground: recordingItem.isRecording ? Appearance.colors.colPrimaryContainer : "transparent"
                     buttonRadius: recordingItem.isRecording ? Appearance.rounding.normal : implicitHeight / 2
-                    onClicked: Quickshell.execDetached([Directories.recordScriptPath])
+                    onClicked: recordingItem.isRecording ? Quickshell.execDetached([Directories.recordScriptPath]) : Quickshell.execDetached(["qs", "-p", Quickshell.shellPath(""), "ipc", "call", "region", "record"])
 
                     Behavior on colBackground { ColorAnimation { duration: 200 } }
                     Behavior on buttonRadius { NumberAnimation { duration: 200; easing.type: Easing.OutCubic } }
@@ -151,10 +152,105 @@ Item {
 
         Component {
             id: screenRecordM3
-            UtilButton {
-                iconText: Persistent.states.record.enable ? "stop_circle" : "screen_record"
-                forceHovered: Persistent.states.record.enable
-                onClicked: Quickshell.execDetached([Directories.recordScriptPath])
+            Item {
+                id: recordingItemM3
+                implicitWidth: btnM3.implicitWidth
+                implicitHeight: btnM3.implicitHeight
+
+                property bool isRecording: Persistent.states.record.enable
+                property int elapsedSeconds: 0
+
+                onIsRecordingChanged: {
+                    if (!isRecording) elapsedSeconds = 0
+                }
+
+                function formatTime(s) {
+                    return Math.floor(s / 60).toString().padStart(2, '0') + ":" + (s % 60).toString().padStart(2, '0')
+                }
+
+                Timer {
+                    interval: 1000
+                    repeat: true
+                    running: recordingItemM3.isRecording
+                    onTriggered: recordingItemM3.elapsedSeconds++
+                }
+
+                Rectangle {
+                    id: btnM3
+                    property bool hovered: mouseArea.containsMouse || recordingItemM3.isRecording
+
+                    implicitWidth: {
+                        if (root.vertical) return 26;
+                        if (recordingItemM3.isRecording) return contentRow.implicitWidth + 14;
+                        return hovered ? 54 : 26;
+                    }
+                    implicitHeight: {
+                        if (!root.vertical) return 26;
+                        if (recordingItemM3.isRecording) return contentRow.implicitHeight + 14;
+                        return hovered ? 54 : 26;
+                    }
+
+                    radius: Appearance.rounding.full
+                    color: hovered ? Appearance.colors.colPrimary : ColorUtils.transparentize(Appearance.colors.colLayer0, 0.8)
+
+                    Behavior on implicitWidth {
+                        NumberAnimation {
+                            duration: Appearance.animation.elementMoveFast.duration
+                            easing.type: Appearance.animation.elementMoveFast.easing
+                        }
+                    }
+                    Behavior on implicitHeight {
+                        NumberAnimation {
+                            duration: Appearance.animation.elementMoveFast.duration
+                            easing.type: Appearance.animation.elementMoveFast.easing
+                        }
+                    }
+                    Behavior on color {
+                        ColorAnimation { duration: Appearance.animation.elementMoveFast.duration }
+                    }
+
+                    Row {
+                        id: contentRow
+                        anchors.centerIn: parent
+                        spacing: 4
+
+                        MaterialSymbol {
+                            anchors.verticalCenter: parent.verticalCenter
+                            iconSize: Appearance.font.pixelSize.large
+                            text: recordingItemM3.isRecording ? "stop_circle" : "screen_record"
+                            color: btnM3.hovered ? Appearance.colors.colOnPrimary : Appearance.colors.colPrimary
+
+                            Behavior on color {
+                                ColorAnimation { duration: Appearance.animation.elementMoveFast.duration }
+                            }
+                        }
+
+                        Revealer {
+                            id: timerRevealer
+                            anchors.verticalCenter: parent.verticalCenter
+                            reveal: recordingItemM3.isRecording && !root.vertical
+
+                            StyledText {
+                                text: recordingItemM3.formatTime(recordingItemM3.elapsedSeconds)
+                                font.pixelSize: Appearance.font.pixelSize.small
+                                font.features: { "tnum": 1 }
+                                font.letterSpacing: -0.3
+                                color: btnM3.hovered ? Appearance.colors.colOnPrimary : Appearance.colors.colPrimary
+
+                                Behavior on color {
+                                    ColorAnimation { duration: Appearance.animation.elementMoveFast.duration }
+                                }
+                            }
+                        }
+                    }
+
+                    MouseArea {
+                        id: mouseArea
+                        anchors.fill: parent
+                        hoverEnabled: true
+                        onClicked: recordingItemM3.isRecording ? Quickshell.execDetached([Directories.recordScriptPath]) : Quickshell.execDetached(["qs", "-p", Quickshell.shellPath(""), "ipc", "call", "region", "record"])
+                    }
+                }
             }
         }
 

--- a/modules/ii/regionSelector/RegionSelection.qml
+++ b/modules/ii/regionSelector/RegionSelection.qml
@@ -218,6 +218,15 @@ PanelWindow {
         root.visible = true;
     }
 
+    Connections {
+        target: Persistent.states.record
+        function onEnableChanged() {
+            if (!Persistent.states.record.enable && root.isRecording) {
+                root.dismiss();
+            }
+        }
+    }
+
     Process {
         id: imageDetectionProcess
         command: ["bash", "-c", `${Directories.scriptPath}/images/find-regions-venv.sh ` 

--- a/modules/ii/regionSelector/RegionSelector.qml
+++ b/modules/ii/regionSelector/RegionSelector.qml
@@ -33,6 +33,17 @@ Scope {
     }
 
     function screenshot() {
+        if (Persistent.states.record.enable) {
+            const saveDir = Config.options.screenSnip.savePath !== "" ? Config.options.screenSnip.savePath : "";
+            if (saveDir !== "") {
+                const cmd = `mkdir -p '${saveDir}' && filePath="${saveDir}/screenshot-$(date '+%Y-%m-%d_%H.%M.%S').png" && grim -g "$(slurp)" "$filePath" && cat "$filePath" | wl-copy && notify-send "Screenshot Saved" "Saved to $filePath" -a "Screen Snip" -i "image-x-generic"`;
+                Quickshell.execDetached(["bash", "-c", cmd]);
+            } else {
+                const cmd = `grim -g "$(slurp)" - | wl-copy && notify-send "Screenshot Copied" "Copied to clipboard" -a "Screen Snip" -i "image-x-generic"`;
+                Quickshell.execDetached(["bash", "-c", cmd]);
+            }
+            return;
+        }
         root.action = RegionSelection.SnipAction.Copy
         root.selectionMode = RegionSelection.SelectionMode.RectCorners
         GlobalStates.regionSelectorOpen = true
@@ -55,18 +66,22 @@ Scope {
     }
 
     function record() {
+        if (Persistent.states.record.enable) {
+            Quickshell.execDetached([Directories.recordScriptPath]);
+            return;
+        }
         root.action = RegionSelection.SnipAction.Record
         root.selectionMode = RegionSelection.SelectionMode.RectCorners
-        // If already open then re-trigger to stop recording
-        if (GlobalStates.regionSelectorOpen) GlobalStates.regionSelectorOpen = false
         GlobalStates.regionSelectorOpen = true
     }
 
     function recordWithSound() {
+        if (Persistent.states.record.enable) {
+            Quickshell.execDetached([Directories.recordScriptPath]);
+            return;
+        }
         root.action = RegionSelection.SnipAction.RecordWithSound
         root.selectionMode = RegionSelection.SelectionMode.RectCorners
-        // If already open then re-trigger to stop recording
-        if (GlobalStates.regionSelectorOpen) GlobalStates.regionSelectorOpen = false
         GlobalStates.regionSelectorOpen = true
     }
 

--- a/scripts/videos/record.sh
+++ b/scripts/videos/record.sh
@@ -3,7 +3,7 @@ CONFIG_FILE="$HOME/.config/illogical-impulse/config.json"
 JSON_PATH=".screenRecord.savePath"
 CUSTOM_PATH=$(jq -r "$JSON_PATH" "$CONFIG_FILE" 2>/dev/null)
 RECORDING_DIR=""
-if [[ -n "$CUSTOM_PATH" ]]; then
+if [[ -n "$CUSTOM_PATH" && "$CUSTOM_PATH" != "null" ]]; then
     RECORDING_DIR="$CUSTOM_PATH"
 else
     RECORDING_DIR="$HOME/Videos"
@@ -48,18 +48,33 @@ for ((i=0;i<${#ARGS[@]};i++)); do
     fi
 done
 
+LAST_FILE_TMP="/tmp/last_recording_path.txt"
+
 if pgrep wf-recorder > /dev/null; then
-    notify-send "Recording Stopped" "Stopped" -a 'Recorder' &
+    SAVED_FILE=$(cat "$LAST_FILE_TMP" 2>/dev/null)
+    if [[ -z "$SAVED_FILE" ]]; then
+        SAVED_FILE="$RECORDING_DIR"
+    fi
+    notify-send "Recording Stopped" "Saved to:\n$SAVED_FILE" -a 'Recorder' -i 'video-x-generic' &
     pkill wf-recorder &
     set_recording_state false
 else
+    FILENAME="recording_$(getdate).mp4"
+    FILEPATH="$RECORDING_DIR/$FILENAME"
+    echo "$FILEPATH" > "$LAST_FILE_TMP"
+
+    AUDIO_MSG="without sound"
+    if [[ $SOUND_FLAG -eq 1 ]]; then
+        AUDIO_MSG="with sound"
+    fi
+
     if [[ $FULLSCREEN_FLAG -eq 1 ]]; then
-        notify-send "Starting recording" 'recording_'"$(getdate)"'.mp4' -a 'Recorder' & disown
+        notify-send "Starting recording ($AUDIO_MSG)" "$FILENAME" -a 'Recorder' & disown
         set_recording_state true
         if [[ $SOUND_FLAG -eq 1 ]]; then
-            wf-recorder -o "$(getactivemonitor)" --pixel-format yuv420p -f './recording_'"$(getdate)"'.mp4' -t --audio="$(getaudiooutput)"
+            wf-recorder -o "$(getactivemonitor)" --pixel-format yuv420p -f "$FILEPATH" -t --audio="$(getaudiooutput)"
         else
-            wf-recorder -o "$(getactivemonitor)" --pixel-format yuv420p -f './recording_'"$(getdate)"'.mp4' -t
+            wf-recorder -o "$(getactivemonitor)" --pixel-format yuv420p -f "$FILEPATH" -t
         fi
     else
         if [[ -n "$MANUAL_REGION" ]]; then
@@ -70,12 +85,12 @@ else
                 exit 1
             fi
         fi
-        notify-send "Starting recording" 'recording_'"$(getdate)"'.mp4' -a 'Recorder' & disown
+        notify-send "Starting recording ($AUDIO_MSG)" "$FILENAME" -a 'Recorder' & disown
         set_recording_state true
         if [[ $SOUND_FLAG -eq 1 ]]; then
-            wf-recorder --pixel-format yuv420p -f './recording_'"$(getdate)"'.mp4' -t --geometry "$region" --audio="$(getaudiooutput)"
+            wf-recorder --pixel-format yuv420p -f "$FILEPATH" -t --geometry "$region" --audio="$(getaudiooutput)"
         else
-            wf-recorder --pixel-format yuv420p -f './recording_'"$(getdate)"'.mp4' -t --geometry "$region"
+            wf-recorder --pixel-format yuv420p -f "$FILEPATH" -t --geometry "$region"
         fi
     fi
     set_recording_state false


### PR DESCRIPTION
### Summary of Changes

This PR improves the screen recording and capture user experience across the top bar, script notifications, and region selection overlay:

1. **M3 Live Recording Timer & Smooth Animations ()**:
   - Added a dynamic timer component (`recordingItemM3` / `screenRecordM3`) displaying elapsed recording time (`MM:SS`) when recording is active.
   - Integrated Material 3 styling with smooth expansion and reveal animations on the bar.

2. **Parallel Screenshot Capture ()**:
   - Updated `screenshot()` to allow taking direct region/fullscreen screenshots via `grim` while a screen recording session is currently active without interrupting the recording flow or opening the region overlay.

3. **Overlay & Trigger Normalization (`modules/ii/regionSelector/RegionSelection.qml` & `RegionSelector.qml`)**:
   - Added automatic dismissal (`root.dismiss()`) of the region selection overlay when recording is stopped (`Persistent.states.record.enable` transitions to `false`).
   - Triggering record actions while already recording will cleanly execute the stop command.

4. **Script & Notification Improvements (`scripts/videos/record.sh`)**:
   - Tracks the exact saved video file path (`/tmp/last_recording_path.txt`) so stop notifications report the precise file destination (`Saved to: ...`).
   - Updated start notifications to explicitly state audio status (`(with sound)` / `(without sound)`).