### PR TITLE
Fix M3 clock pill with seconds

### DIFF
--- a/modules/ii/bar/ClockWidget.qml
+++ b/modules/ii/bar/ClockWidget.qml
@@ -136,9 +136,8 @@ BarWidgetSwitcher {
             id: pill
 
             property var timeParts: DateTime.time.split(/[: ]/)
-            property string hours: timeParts[0] ?? "00"
-            property string minutes: timeParts[1] ?? "00"
-            property string ampm: timeParts[2] ?? ""
+            property string ampm: timeParts.find(part => /^(am|pm)$/i.test(part)) ?? ""
+            property string time: timeParts.filter(part => !/^(am|pm)$/i.test(part)).join(":")
 
             StyledText {
                 visible: root.showDate
@@ -161,7 +160,7 @@ BarWidgetSwitcher {
                     font.pixelSize: Appearance.font.pixelSize.smallie
                     color: Appearance.colors.colOnPrimary
                     font.weight: Font.Bold
-                    text: pill.ampm !== "" ? pill.hours.padStart(2, "0") + ":" + pill.minutes.padStart(2, "0") : DateTime.time
+                    text: pill.time
                     font.features: { "tnum": 1 }
                     font.letterSpacing: -0.4
                 }


### PR DESCRIPTION
Fixes bug where the clock with 3 values (hh:mm:ss) didnt have the M3 pill for the third value as it styled it with the AM/PM styles.

before: 
<img width="201" height="48" alt="image" src="https://github.com/user-attachments/assets/fc82ede0-a4ec-49f6-a534-6594d037ba9d" />

---

after: 
<img width="222" height="53" alt="image" src="https://github.com/user-attachments/assets/dbf2468b-f5ec-40d7-9816-078ad26ad592" />

hh:mm:ss AP:
<img width="216" height="50" alt="image" src="https://github.com/user-attachments/assets/7c63bfb6-af39-47cf-9096-349f1ca91ac0" />

only hh:mm AP:
<img width="204" height="51" alt="image" src="https://github.com/user-attachments/assets/a0629674-d21a-4973-83e9-ae0a2f3d1bec" />

works with infinite components - hh:mm:ss:ss:ss:ss AP: 
<img width="239" height="53" alt="image" src="https://github.com/user-attachments/assets/9ad23e82-2446-48c9-a305-2b2b5b80e1f0" />
