### PR TITLE
Added gamemode preset option

### DIFF
--- a/modules/common/Config.qml
+++ b/modules/common/Config.qml
@@ -154,7 +154,9 @@ Singleton {
                 property string avatarPicture: ""
                 property string descriptionText: "::distro::"
                 property string displayName: ""
-
+                property bool gameModePresetEnabled: false
+                property bool gameModePresetVisible: true
+                property string gameModePresetName: "GameMode"
             }
 
             property JsonObject hyprland: JsonObject {

--- a/modules/common/Persistent.qml
+++ b/modules/common/Persistent.qml
@@ -83,6 +83,17 @@ Singleton {
                 property bool inhibit: false
             }
 
+            property JsonObject preset: JsonObject {
+                property string currentPreset: ""
+                property string previousPreset: ""
+                property string beforeGameMode: ""
+                property string lastGameMode: ""
+            }
+
+            property JsonObject gameMode: JsonObject {
+                property bool enabled: false
+            }
+
             property JsonObject record: JsonObject {
                 property bool enable: false
             }

--- a/modules/common/models/quickToggles/GameModeToggle.qml
+++ b/modules/common/models/quickToggles/GameModeToggle.qml
@@ -1,17 +1,25 @@
 import QtQuick
 import Quickshell.Io
+import qs.modules.common
 import qs.modules.common.models.hyprland
 import qs.services
 
 QuickToggleModel {
     id: root
     name: Translation.tr("Game mode")
-    toggled: !confOpt.value
+    toggled: Persistent.states?.gameMode?.enabled ?? false
     icon: "gamepad"
 
+    function setEnabled(enabled) {
+        root.toggled = enabled
+        Persistent.states.gameMode.enabled = enabled
+    }
+
     mainAction: () => {
-        root.toggled = !root.toggled;
-        if (root.toggled) {
+        const shouldEnable = !root.toggled;
+        root.setEnabled(shouldEnable);
+
+        if (shouldEnable) {
             HyprlandConfig.setMany({
                 "animations:enabled": 0,
                 "decoration:shadow:enabled": 0,
@@ -22,23 +30,46 @@ QuickToggleModel {
                 "decoration:rounding": 0,
                 "general:allow_tearing": 1
             });
-        } else {
-            HyprlandConfig.resetMany([ //
-                "animations:enabled", //
-                "decoration:shadow:enabled", //
-                "decoration:blur:enabled", //
-                "general:gaps_in", //
-                "general:gaps_out", //
-                "general:border_size", //
-                "decoration:rounding", //
-                "general:allow_tearing", //
-            ]);
+
+            Presets.activateGameMode();
+            return;
         }
+
+        if (Presets.restorePreviousPreset()) {
+            return;
+        }
+
+        HyprlandConfig.resetMany([ //
+            "animations:enabled", //
+            "decoration:shadow:enabled", //
+            "decoration:blur:enabled", //
+            "general:gaps_in", //
+            "general:gaps_out", //
+            "general:border_size", //
+            "decoration:rounding", //
+            "general:allow_tearing", //
+        ]);
     }
 
     HyprlandConfigOption {
         id: confOpt
         key: "animations:enabled"
+    }
+
+    Component.onCompleted: {
+        if (Persistent.states?.gameMode?.enabled ?? false) {
+            root.toggled = true
+            HyprlandConfig.setMany({
+                "animations:enabled": 0,
+                "decoration:shadow:enabled": 0,
+                "decoration:blur:enabled": 0,
+                "general:gaps_in": 0,
+                "general:gaps_out": 0,
+                "general:border_size": 1,
+                "decoration:rounding": 0,
+                "general:allow_tearing": 1
+            });
+        }
     }
 
     tooltipText: Translation.tr("Game mode")

--- a/modules/ii/settings/pages/Profile.qml
+++ b/modules/ii/settings/pages/Profile.qml
@@ -260,6 +260,39 @@ ContentPage {
                 }
             }
 
+            ContentSubsection {
+                title: Translation.tr("GameMode preset")
+
+                GroupedList {
+                    ConfigSwitch {
+                        text: Translation.tr("Use GameMode preset")
+                        checked: Config.options.profile.gameModePresetEnabled
+                        onCheckedChanged: {
+                            Config.options.profile.gameModePresetEnabled = checked
+                        }
+                    }
+
+                    ConfigSwitch {
+                        text: Translation.tr("Show GameMode preset in settings")
+                        checked: Config.options.profile.gameModePresetVisible
+                        onCheckedChanged: {
+                            Config.options.profile.gameModePresetVisible = checked
+                        }
+                    }
+
+                    ConfigTextArea {
+                        Layout.fillWidth: true
+                        buttonIcon: "stadia_controller"
+                        text: Translation.tr("GameMode preset name")
+                        placeholderText: Translation.tr("GameMode")
+                        value: Config.options.profile.gameModePresetName
+                        onValueChanged: {
+                            Config.options.profile.gameModePresetName = value.trim() || "GameMode"
+                        }
+                    }
+                }
+            }
+
             StyledText {
                 Layout.fillWidth: true
                 Layout.topMargin: 40
@@ -285,6 +318,7 @@ ContentPage {
                         required property string filePath
 
                         property string presetName: fileName.replace(".json", "")
+                        property bool isGameModePreset: presetName === Config.options.profile.gameModePresetName
                         property string presetWallpaper: ""
                         property string presetDescription: ""
 
@@ -305,6 +339,7 @@ ContentPage {
                             }
                         }
 
+                        visible: !(presetDelegate.isGameModePreset && !Config.options.profile.gameModePresetVisible)
                         imageSource: presetDelegate.presetWallpaper
                         title: presetDelegate.presetName
                         description: presetDelegate.presetDescription !== "" ? presetDelegate.presetDescription : Translation.tr("Saved preset")

--- a/modules/ii/sidebarRight/quickToggles/classicStyle/GameMode.qml
+++ b/modules/ii/sidebarRight/quickToggles/classicStyle/GameMode.qml
@@ -10,12 +10,20 @@ QuickToggleButton {
     toggled: toggled
 
     onClicked: {
-        root.toggled = !root.toggled
-        if (root.toggled) {
+        const shouldEnable = !root.toggled
+        root.toggled = shouldEnable
+
+        if (shouldEnable) {
             Quickshell.execDetached(["bash", "-c", `hyprctl --batch "keyword animations:enabled 0; keyword decoration:shadow:enabled 0; keyword decoration:blur:enabled 0; keyword general:gaps_in 0; keyword general:gaps_out 0; keyword general:border_size 1; keyword decoration:rounding 0; keyword general:allow_tearing 1"`])
-        } else {
-            Quickshell.execDetached(["hyprctl", "reload"])
+            Presets.activateGameMode()
+            return
         }
+
+        if (Presets.restorePreviousPreset()) {
+            return
+        }
+
+        Quickshell.execDetached(["hyprctl", "reload"])
     }
     Process {
         id: fetchActiveState

--- a/services/Booru.qml
+++ b/services/Booru.qml
@@ -59,8 +59,8 @@ Singleton {
         },
         "konachan": {
             "name": "Konachan",
-            "url": "https://konachan.net",
-            "api": "https://konachan.net/post.json",
+            "url": "https://konachan.com",
+            "api": "https://konachan.com/post.json",
             "description": Translation.tr("For desktop wallpapers | Good quality"),
             "mapFunc": (response) => {
                 return response.map(item => {

--- a/services/Presets.qml
+++ b/services/Presets.qml
@@ -13,6 +13,29 @@ Singleton {
     id: root
 
     property alias folderModel: presetsFolderModel
+    property string currentPreset: Persistent.states?.preset?.currentPreset ?? ""
+    property string previousPreset: Persistent.states?.preset?.previousPreset ?? ""
+    property string beforeGameMode: Persistent.states?.preset?.beforeGameMode ?? ""
+    property string lastGameMode: Persistent.states?.preset?.lastGameMode ?? ""
+
+    function syncFromPersistent() {
+        const savedCurrent = Persistent.states?.preset?.currentPreset ?? ""
+        const savedPrevious = Persistent.states?.preset?.previousPreset ?? ""
+        const savedBeforeGameMode = Persistent.states?.preset?.beforeGameMode ?? ""
+
+        if (savedCurrent.length > 0) root.currentPreset = savedCurrent
+        if (savedPrevious.length > 0) root.previousPreset = savedPrevious
+        if (savedBeforeGameMode.length > 0) root.beforeGameMode = savedBeforeGameMode
+    }
+
+    Component.onCompleted: root.syncFromPersistent()
+
+    Connections {
+        target: Persistent
+        function onReadyChanged() {
+            if (Persistent.ready) root.syncFromPersistent()
+        }
+    }
 
     FolderListModel {
         id: presetsFolderModel
@@ -38,7 +61,7 @@ Singleton {
     }
 
     function save(rawInput) {
-        const raw = rawInput.trim()
+        const raw = (rawInput ?? "").trim()
         if (raw.length === 0) return
 
         const commaIndex = raw.indexOf(",")
@@ -58,12 +81,141 @@ Singleton {
     }
 
     function apply(name) {
+        const presetName = (name ?? "").trim()
+        if (presetName.length === 0) return
+
         GlobalStates.settingsOpen = false
         Wallpapers.confirmedPath = ""
         Wallpapers.previewPath = ""
-        Quickshell.execDetached(["bash", Directories.presetsScriptPath, "--apply", name])
+
+        root.currentPreset = presetName
+        Persistent.states.preset.currentPreset = presetName
+        Quickshell.execDetached(["bash", Directories.presetsScriptPath, "--apply", presetName])
     }
 
+    function gameModePresetName() {
+        const presetName = (Config.options.profile.gameModePresetName ?? "").trim()
+        return presetName.length > 0 ? presetName : "GameMode"
+    }
+
+    function ensureGameModePresetExists() {
+        if (!Config.options.profile.gameModePresetEnabled) return
+
+        const targetPreset = gameModePresetName()
+        const targetFile = `${targetPreset}.json`
+        let found = false
+
+        for (let i = 0; i < presetsFolderModel.count; ++i) {
+            const fileName = presetsFolderModel.get(i, "fileName") ?? ""
+            if (fileName === targetFile) {
+                found = true
+                break
+            }
+        }
+
+        if (!found) {
+            save(targetPreset)
+        }
+    }
+
+    function saveCurrentPresetBeforeGameMode() {
+        if (!Config.options.profile.gameModePresetEnabled) return
+
+        const activePreset = (root.currentPreset.length > 0 ? root.currentPreset : (Persistent.states?.preset?.currentPreset ?? "")).trim()
+        const targetPreset = gameModePresetName()
+        if (activePreset === "" || activePreset === targetPreset) {
+            if (root.previousPreset.length > 0 && root.previousPreset !== targetPreset) {
+                root.beforeGameMode = root.previousPreset
+                Persistent.states.preset.beforeGameMode = root.previousPreset
+            }
+            return
+        }
+
+        root.beforeGameMode = activePreset
+        Persistent.states.preset.beforeGameMode = activePreset
+        root.previousPreset = activePreset
+        Persistent.states.preset.previousPreset = activePreset
+
+        save(activePreset)
+    }
+
+    function restorePreviousPreset() {
+        save(gameModePresetName())
+        if (!Config.options.profile.gameModePresetEnabled) {
+            root.lastGameMode = ""
+            Persistent.states.preset.lastGameMode = ""
+            root.beforeGameMode = ""
+            Persistent.states.preset.beforeGameMode = ""
+            root.previousPreset = ""
+            Persistent.states.preset.previousPreset = ""
+
+            HyprlandConfig.resetMany([
+                "animations:enabled",
+                "decoration:shadow:enabled",
+                "decoration:blur:enabled",
+                "general:gaps_in",
+                "general:gaps_out",
+                "general:border_size",
+                "decoration:rounding",
+                "general:allow_tearing",
+            ])
+            return true
+        }
+
+        // Gather fallback chain across root and persistent states, filtering out the game mode name itself
+        const targetPreset = gameModePresetName()
+        let presetName = (root.beforeGameMode || Persistent.states?.preset?.beforeGameMode || "").trim()
+        
+        if (presetName === "" || presetName === targetPreset) {
+            presetName = (root.previousPreset || Persistent.states?.preset?.previousPreset || "").trim()
+        }
+
+        if (presetName === "" || presetName === targetPreset) {
+            console.warn("Presets: Cannot restore previous preset because no valid non-gamemode preset was found.")
+            return false
+        }
+
+        // Clear tracking states
+        root.lastGameMode = ""
+        Persistent.states.preset.lastGameMode = ""
+        root.beforeGameMode = ""
+        Persistent.states.preset.beforeGameMode = ""
+        root.previousPreset = ""
+        Persistent.states.preset.previousPreset = ""
+
+        HyprlandConfig.resetMany([
+            "animations:enabled",
+            "decoration:shadow:enabled",
+            "decoration:blur:enabled",
+            "general:gaps_in",
+            "general:gaps_out",
+            "general:border_size",
+            "decoration:rounding",
+            "general:allow_tearing",
+        ])
+        
+        apply(presetName)
+        return true
+    }
+
+    function activateGameMode() {
+        if (!Config.options.profile.gameModePresetEnabled) {
+            root.lastGameMode = ""
+            Persistent.states.preset.lastGameMode = ""
+            return
+        }
+
+        ensureGameModePresetExists()
+        saveCurrentPresetBeforeGameMode()
+
+        const targetPreset = gameModePresetName()
+        root.lastGameMode = targetPreset
+        Persistent.states.preset.lastGameMode = targetPreset
+        apply(targetPreset)
+    }
+
+    
+ 
     function remove(name) {
         deleteProc.command = ["bash", Directories.presetsScriptPath, "--remove", name]
         deleteProc.running = true


### PR DESCRIPTION
### Summary
Added a game mode preset option that automatically toggles shell configurations for maximum performance when gaming, and restores the previous state when game mode is turned off. The state persists across Quick Settings (QS) restarts.

### Changes
- **State Restoration:** Automatically switches back to the previously active preset once game mode is deactivated.
- **Persistence:** Saved state and logic survive Quick Settings / shell restarts.

### How to test
1. Enable Game Mode Preset in profile settings
2. Create Preset as named is settings(or start game mode if will create automatically)
3. Customise preset
4. Disable/Enable game mode to test behavior