### PR TITLE
feat(bar): tell special workspaces apart on the vertical bar

### DIFF
--- a/modules/ii/bar/Workspaces.qml
+++ b/modules/ii/bar/Workspaces.qml
@@ -283,6 +283,7 @@ ButtonMouseArea {
         Behavior on opacity {} // Don't animate, as specialBlur is already animated
 
         sourceComponent: Pill {
+            id: specialWsPill
             anchors.centerIn: parent
             property real undirectionalWidth: root.activeWorkspaceSize
             property real undirectionalLength: {
@@ -296,10 +297,50 @@ ButtonMouseArea {
             implicitWidth: root.vertical ? undirectionalWidth : undirectionalLength
             implicitHeight: root.vertical ? undirectionalLength : undirectionalWidth
 
+            readonly property string specialIcon: {
+                switch (wsModel.specialWorkspaceName) {
+                case "music": return "music_cast";
+                case "communication": return "forum";
+                case "todo": return "checklist";
+                case "sysmon": return "monitor_heart";
+                case "claude": return "file:///usr/lib/claude-desktop/resources/TrayIconLinux.png";
+                default: return "star";
+                }
+            }
+            readonly property bool specialIconIsImage: specialIcon.startsWith("file://") && specialWsImage.status !== Image.Error
+
+            MaterialSymbol {
+                anchors.centerIn: parent
+                visible: root.vertical && !specialWsPill.specialIconIsImage
+                text: specialWsPill.specialIconIsImage ? "" : (specialWsPill.specialIcon.startsWith("file://") ? "star" : specialWsPill.specialIcon)
+                color: Appearance.colors.colOnPrimary
+                iconSize: root.specialTextSize
+            }
+
+            Image {
+                id: specialWsImage
+                anchors.centerIn: parent
+                visible: root.vertical && specialWsPill.specialIconIsImage
+                source: specialWsPill.specialIcon.startsWith("file://") ? specialWsPill.specialIcon : ""
+                width: root.specialTextSize
+                height: root.specialTextSize
+                sourceSize.width: width * 2
+                sourceSize.height: height * 2
+                fillMode: Image.PreserveAspectFit
+                smooth: true
+                layer.enabled: true
+                layer.effect: MultiEffect {
+                    brightness: 1
+                    colorization: 1
+                    colorizationColor: Appearance.colors.colOnPrimary
+                }
+            }
+
             StyledText {
                 id: specialWsText
                 anchors.centerIn: parent
-                text: (!root.vertical ? wsModel.specialWorkspaceName : "S")
+                visible: !root.vertical
+                text: wsModel.specialWorkspaceName
                 color: Appearance.colors.colOnPrimary
                 font.pixelSize: root.specialTextSize
             }


### PR DESCRIPTION
On the vertical bar there is no room for the workspace name, so the special workspace pill always draws a literal `S`:

```qml
text: (!root.vertical ? wsModel.specialWorkspaceName : "S")
```

With more than one special workspace, you can't tell which one is open.

This maps each one to an icon instead:

| workspace | icon |
|---|---|
| `music` | `music_cast` |
| `communication` | `forum` |
| `todo` | `checklist` |
| `sysmon` | `monitor_heart` |
| anything else | `star` |

Claude has no Material Symbols glyph, so it uses the app's tray icon, tinted to match the others. If the file isn't there, it falls back to the generic icon.

The horizontal bar is unchanged — it has room for the name.

Inspired by how [Caelestia](https://github.com/caelestia-dots/shell) does it (`utils/Icons.qml`).

One file, +42/-1. Tested on Hyprland 0.56.2, Quickshell 0.3.0.
