### PR TITLE
fix: make monochromeIcons:false actually disable workspace icon tinting

### DIFF
--- a/modules/ii/bar/Workspaces.qml
+++ b/modules/ii/bar/Workspaces.qml
@@ -248,7 +248,7 @@ ButtonMouseArea {
                             implicitWidth: appIcon.implicitWidth
                             implicitHeight: appIcon.implicitHeight
                             colorizationColor: Appearance.m3colors.darkmode ? Appearance.colors.colOnSecondaryContainer : Appearance.colors.colOnPrimary
-                            colorization: Config.options.bar.workspaces.monochromeIcons ? 0.8 : 0.5
+                            colorization: Config.options.bar.workspaces.monochromeIcons ? 0.8 : 0
                             brightness: 0
                             source: appIcon
 

--- a/modules/ii/sidebarRight/quickToggles/androidStyle/AndroidNightLightToggle.qml
+++ b/modules/ii/sidebarRight/quickToggles/androidStyle/AndroidNightLightToggle.qml
@@ -7,5 +7,13 @@ import Quickshell
 
 AndroidQuickToggleButton {
     toggleModel: NightLightToggle {}
+
+    // Reconcile with the real hyprsunset state on load, the same way the
+    // classic-style toggle does (classicStyle/NightLight.qml). Without this the
+    // button just renders Hyprsunset.temperatureActive, which is only ever set
+    // optimistically by enable/disableTemperature() -- so if the underlying
+    // command failed, or the temperature changed outside the shell, the toggle
+    // stays stuck showing the wrong state until it's manually cycled.
+    Component.onCompleted: Hyprsunset.fetchState()
 }
 

--- a/services/Hyprsunset.qml
+++ b/services/Hyprsunset.qml
@@ -101,8 +101,21 @@ Singleton {
         if (root.isNiri) {
             root.startNiriSunset(root.colorTemperature);
         } else {
-            root.startHyprsunset();
-            Quickshell.execDetached(["bash", "-c", `hyprctl hyprsunset temperature ${root.colorTemperature}`]);
+            // Start hyprsunset and set the temperature in a single shell command so
+            // the two can't race. They used to be separate detached processes: when
+            // hyprsunset wasn't already running, the hyprctl call fired before its
+            // IPC socket existed, failed silently, and left the screen unchanged
+            // while temperatureActive was still set to true below.
+            // "Couldn't" is the same failure sentinel fetchProc keys off of.
+            Quickshell.execDetached(["bash", "-c",
+                `pidof hyprsunset >/dev/null 2>&1 || (hyprsunset >/dev/null 2>&1 &)
+                 for i in $(seq 30); do
+                     case "$(hyprctl hyprsunset temperature 2>&1)" in
+                         Couldn*) sleep 0.1 ;;
+                         *) break ;;
+                     esac
+                 done
+                 hyprctl hyprsunset temperature ${root.colorTemperature}`]);
         }
         root.temperatureActive = true;
     }


### PR DESCRIPTION
The Colorizer on workspace app icons was always active, with colorization switching between 0.8 and 0.5. That meant `bar.workspaces.monochromeIcons: false` still applied a 50% tint toward colOnSecondaryContainer/colOnPrimary, so app icons could never render in their true colors.

Stock ii wraps the whole Desaturate + ColorOverlay effect in a Loader gated on `active: monochromeIcons`, so off means off. Restore that behaviour by using 0 instead of 0.5 for the disabled case.