### PR TITLE
feat(i18n): add read-only translation drift check

### DIFF
--- a/translations/tools/README.md
+++ b/translations/tools/README.md
@@ -6,6 +6,7 @@ This suite is used to manage project translation files, automatically extract tr
 
 ### 1. `translation-manager.py` - Main Translation Manager
 - Extract translatable texts
+- Check translation drift without modifying files
 - Compare and update translation files
 - Interactive addition/removal of translation keys
 
@@ -32,6 +33,12 @@ cd .config/quickshell/translations/tools
 # Show current translation status
 ./manage-translations.sh status
 
+# Check all languages for missing or stale keys
+./manage-translations.sh check
+
+# Check a specific language
+./manage-translations.sh check -l zh_CN
+
 # Extract translatable texts
 ./manage-translations.sh extract
 
@@ -57,6 +64,25 @@ Or run from the project root:
 
 ## Detailed Usage
 
+### Translation Drift Check
+
+Use `check` for a read-only comparison between strings currently referenced by
+the QML/JavaScript source and the keys in each translation file:
+
+```bash
+# Check every language
+./manage-translations.sh check
+
+# Check one language
+./manage-translations.sh check -l zh_CN
+```
+
+The command reports missing keys, stale extra keys, and extra keys intentionally
+preserved with `/*keep*/`. It exits with status `0` when checked files are in
+sync, `1` when drift is detected, and `2` for invalid input such as an unknown
+language. Translation files are never changed, so the command can be used in
+CI or pre-commit checks.
+
 ### Translation Manager (`translation-manager.py`)
 
 Basic usage:
@@ -69,6 +95,9 @@ Basic usage:
 
 # Extract translatable texts only
 ./translation-manager.py --extract-only
+
+# Check translation drift without changing files
+./translation-manager.py --check
 
 # Show extracted texts
 ./translation-manager.py --extract-only --show-temp

--- a/translations/tools/manage-translations.sh
+++ b/translations/tools/manage-translations.sh
@@ -5,7 +5,7 @@ set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TRANSLATIONS_DIR="$(dirname "$SCRIPT_DIR")"
-SOURCE_DIR="$(dirname "$(dirname "$TRANSLATIONS_DIR")")"
+SOURCE_DIR="$(dirname "$TRANSLATIONS_DIR")"
 
 show_help() {
     echo "Translation Management Tool - Convenient Wrapper"
@@ -14,6 +14,7 @@ show_help() {
     echo ""
     echo "Commands:"
     echo "  extract      Extract translatable texts to temporary file"
+    echo "  check        Check for missing or stale keys without changing files"
     echo "  update       Update translation files (add missing/remove extra keys)"
     echo "  clean        Clean unused translation keys"
     echo "  sync         Sync keys across all language files"
@@ -28,6 +29,8 @@ show_help() {
     echo ""
     echo "Examples:"
     echo "  $0 extract                    # Extract translatable texts"
+    echo "  $0 check                      # Check all languages for translation drift"
+    echo "  $0 check -l zh_CN             # Check one language for translation drift"
     echo "  $0 update -l zh_CN           # Update Chinese translations"
     echo "  $0 update                    # Update all translations"
     echo "  $0 clean                     # Clean unused keys"
@@ -88,7 +91,7 @@ while [[ $# -gt 0 ]]; do
             show_help
             exit 0
             ;;
-        extract|update|clean|sync|status)
+        extract|check|update|clean|sync|status)
             if [ -n "$COMMAND" ]; then
                 echo "Error: Only one command can be specified"
                 exit 1
@@ -127,6 +130,14 @@ case $COMMAND in
     extract)
         echo "Extracting translatable texts..."
         python3 "$SCRIPT_DIR/translation-manager.py" $BASE_ARGS $YES_FLAG --extract-only --show-temp
+        ;;
+    check)
+        echo "Checking translation drift..."
+        if [ -n "$LANG_CODE" ]; then
+            python3 "$SCRIPT_DIR/translation-manager.py" $BASE_ARGS --language "$LANG_CODE" --check
+        else
+            python3 "$SCRIPT_DIR/translation-manager.py" $BASE_ARGS --check
+        fi
         ;;
     update)
         echo "Updating translation files..."

--- a/translations/tools/translation-manager.py
+++ b/translations/tools/translation-manager.py
@@ -210,6 +210,44 @@ class TranslationManager:
         if self.temp_extracted_file and os.path.exists(self.temp_extracted_file):
             os.unlink(self.temp_extracted_file)
 
+
+def check_translation_drift(
+    manager: TranslationManager,
+    extracted_texts: Set[str],
+    languages: List[str]
+) -> int:
+    """Report translation drift without modifying translation files."""
+    print("\n=== Translation Drift Check ===")
+    drifted_languages = 0
+
+    for lang in languages:
+        missing_keys, extra_keys = manager.compare_translations(extracted_texts, lang)
+        translations = manager.load_translation_file(lang)
+        ignored_extra_keys = {
+            key for key in extra_keys
+            if isinstance(translations.get(key, ""), str)
+            and translations.get(key, "").strip().endswith("/*keep*/")
+        }
+        actionable_extra_keys = extra_keys - ignored_extra_keys
+        has_drift = bool(missing_keys or actionable_extra_keys)
+
+        if has_drift:
+            drifted_languages += 1
+
+        status = "DRIFT" if has_drift else "OK"
+        print(
+            f"  {lang}: {status} "
+            f"(missing: {len(missing_keys)}, extra: {len(actionable_extra_keys)}, "
+            f"ignored: {len(ignored_extra_keys)})"
+        )
+
+    if drifted_languages:
+        print(f"\nTranslation drift detected in {drifted_languages} language file(s).")
+        return 1
+
+    print("\nNo translation drift detected.")
+    return 0
+
 def main():
     parser = argparse.ArgumentParser(description="Translation file management tool")
     parser.add_argument("--translations-dir", "-t", 
@@ -224,6 +262,8 @@ def main():
                        help="Only extract translatable texts to temporary file")
     parser.add_argument("--show-temp", action="store_true",
                        help="Show temporary extracted file content")
+    parser.add_argument("--check", action="store_true",
+                       help="Check for translation drift without modifying files")
     parser.add_argument("-y", "--yes", action="store_true",
                        help="Skip all confirmation prompts (auto-confirm)")
     
@@ -265,6 +305,17 @@ def main():
         
         # Get available languages
         available_languages = manager.get_available_languages()
+
+        if args.check:
+            if not available_languages:
+                print("Error: No translation files found")
+                return 2
+            if args.language and args.language not in available_languages:
+                print(f"Error: Translation file does not exist: {args.language}.json")
+                return 2
+
+            check_languages = [args.language] if args.language else available_languages
+            return check_translation_drift(manager, extracted_texts, check_languages)
         
         if args.language:
             target_languages = [args.language]
@@ -331,4 +382,4 @@ def main():
         manager.cleanup()
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- add a read-only `check` command to the translation manager and wrapper
- report missing, stale, and intentionally kept translation keys per language
- return CI-friendly exit codes: `0` for clean, `1` for drift, and `2` for invalid input
- fix the wrapper source root so it scans this shell instead of its parent directory
- document all-language and single-language usage

## Why

The existing `status` command only reports raw key counts, while the update flow is interactive and may modify files. There was no non-mutating way to detect whether source strings and translation keys had drifted.

The wrapper also resolved `SOURCE_DIR` one directory above the repository. In a normal Quickshell installation this can scan sibling shell configurations and produce unrelated translation keys.

This change provides a focused checker that can be run locally, from pre-commit hooks, or in CI without changing translation files. It does not add a workflow that would fail the repository's current drift.

## Verification

- `bash -n translations/tools/manage-translations.sh`
- `python3 -m py_compile translations/tools/translation-manager.py`
- `git diff --check`
- fixture with no drift returns `0`
- fixture with missing/stale keys returns `1`
- unknown language returns `2`
- fixture keys ending in `/*keep*/` are reported as ignored, not stale
- `bash translations/tools/manage-translations.sh check -l en_US` reports the current repository drift as expected: 217 missing and 110 extra keys
