### PR TITLE
fix: prevent local directory deletion on failed git clone

### DIFF
--- a/modules/ii/settings/pages/About.qml
+++ b/modules/ii/settings/pages/About.qml
@@ -24,11 +24,27 @@ ContentPage {
     }
 
     function runUpdateDots() {
-        Quickshell.execDetached([
-            "kitty", "--hold",
-            "bash", "-c",
-            "killall qs; sleep 0.5; cd ~/.config/quickshell/ && rm -rf end4-pC && git clone https://github.com/pctrade/end4-pC.git && nohup qs -c end4-pC > /tmp/qs.log 2>&1 &"
-        ])
+        const updateScript = `
+            set -e
+            DIR="$HOME/.config/quickshell"
+
+            # Download to temp first
+            rm -rf "$DIR/end4-pC-tmp"
+            git clone https://github.com/pctrade/end4-pC.git "$DIR/end4-pC-tmp"
+
+            # Apply update
+            rm -rf "$DIR/end4-pC-old"
+            [ -d "$DIR/end4-pC" ] && mv "$DIR/end4-pC" "$DIR/end4-pC-old"
+            mv "$DIR/end4-pC-tmp" "$DIR/end4-pC"
+
+            # Reload
+            killall qs 2>/dev/null || true
+            sleep 0.5
+            qs -c end4-pC >/tmp/qs.log 2>&1 &
+            disown
+        `
+
+        Quickshell.execDetached(["kitty", "--hold", "bash", "-c", updateScript])
         Qt.callLater(() => GlobalStates.settingsOpen = false)
     }
 


### PR DESCRIPTION
The previous script deleted the config if the internet dropped. I refactored it to make it safe by cloning to a temp folder first before swapping.