### PR TITLE
feat: add adaptive Bluetooth battery bar

### DIFF
--- a/GlobalStates.qml
+++ b/GlobalStates.qml
@@ -9,6 +9,7 @@ pragma ComponentBehavior: Bound
 
 Singleton {
     id: root
+    signal requestBluetoothDialog()
     property bool barOpen: true
     property bool crosshairOpen: false
     property bool sidebarLeftOpen: false

--- a/modules/common/Config.qml
+++ b/modules/common/Config.qml
@@ -432,7 +432,7 @@ Singleton {
                 property JsonObject layouts: JsonObject {
                     property list<string> leftLayout: ["launcherButton", "workspaces", "activeWindow"]
                     property list<string> middleLayout: ["clockWidget"]
-                    property list<string> rightLayout: ["sysTray", "utilButtons", "systemIcons", "powerButton"]
+                    property list<string> rightLayout: ["sysTray", "utilButtons", "systemIcons", "bluetooth", "powerButton"]
                 }
                 
                 property list<string> screenList: [] // List of names, like "eDP-1", find out with 'hyprctl monitors' command

--- a/modules/common/Icons.qml
+++ b/modules/common/Icons.qml
@@ -7,15 +7,27 @@ Singleton {
     id: root
 
     function getBluetoothDeviceMaterialSymbol(systemIconName: string): string {
-        if (systemIconName.includes("headset") || systemIconName.includes("headphones"))
+        const iconName = (systemIconName || "").toLowerCase();
+
+        if (iconName.includes("earbud") || iconName.includes("earphone") || iconName.includes("in-ear"))
+            return "earbuds";
+        if (iconName.includes("headset") || iconName.includes("headphones"))
             return "headphones";
-        if (systemIconName.includes("audio"))
+        if (iconName.includes("speaker") || iconName.includes("audio"))
             return "speaker";
-        if (systemIconName.includes("phone"))
-            return "smartphone";
-        if (systemIconName.includes("mouse"))
+        if (iconName.includes("gamepad") || iconName.includes("gaming") || iconName.includes("joystick") || iconName.includes("controller"))
+            return "gamepad";
+        if (iconName.includes("phone"))
+            return "phone";
+        if (iconName.includes("tablet"))
+            return "tablet";
+        if (iconName.includes("computer") || iconName.includes("laptop"))
+            return "computer";
+        if (iconName.includes("printer"))
+            return "printer";
+        if (iconName.includes("mouse"))
             return "mouse";
-        if (systemIconName.includes("keyboard"))
+        if (iconName.includes("keyboard"))
             return "keyboard";
         return "bluetooth";
     }

--- a/modules/common/models/quickToggles/BluetoothToggle.qml
+++ b/modules/common/models/quickToggles/BluetoothToggle.qml
@@ -17,7 +17,7 @@ QuickToggleModel {
     available: BluetoothStatus.available
     toggled: BluetoothStatus.enabled
     mainAction: () => {
-        Bluetooth.defaultAdapter.enabled = !Bluetooth.defaultAdapter?.enabled
+        BluetoothStatus.togglePower()
     }
     hasMenu: true
 }

--- a/modules/ii/bar/Bluetooth.qml
+++ b/modules/ii/bar/Bluetooth.qml
@@ -43,8 +43,6 @@ MouseArea {
     onClicked: mouse => {
         if (mouse.button === Qt.RightButton) {
             GlobalStates.requestBluetoothDialog();
-        } else {
-            BluetoothStatus.togglePower();
         }
     }
 

--- a/modules/ii/bar/Bluetooth.qml
+++ b/modules/ii/bar/Bluetooth.qml
@@ -1,0 +1,121 @@
+import qs
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import QtQuick
+import QtQuick.Layouts
+
+MouseArea {
+    id: root
+
+    property bool vertical: false
+    property bool isMaterial: Config.options.bar.cornerStyle === 3
+    property bool hovered: containsMouse
+    readonly property var screen: root.QsWindow?.window?.screen
+    readonly property int screenWidth: screen?.width ?? 1920
+    readonly property bool veryConstrained: !root.vertical
+        && screenWidth <= Appearance.sizes.barHellaShortenScreenWidthThreshold
+    readonly property var connectedDevice: BluetoothStatus.primaryConnectedDevice
+    readonly property var batteryDevice: BluetoothStatus.primaryBatteryDevice
+    readonly property bool hasBattery: !!batteryDevice
+    readonly property real batteryPercentage: hasBattery
+        ? Math.max(0, Math.min(1, Number(batteryDevice.battery)))
+        : 0
+    readonly property bool isLow: hasBattery
+        && batteryPercentage <= Config.options.battery.low / 100
+    readonly property string deviceName: connectedDevice?.name ?? ""
+    readonly property string stateIcon: BluetoothStatus.connected
+        ? Icons.getBluetoothDeviceMaterialSymbol(connectedDevice?.icon || "")
+        : BluetoothStatus.enabled ? "bluetooth" : "bluetooth_disabled"
+    readonly property string percentageText: `${Math.round(batteryPercentage * 100)}%`
+
+    visible: BluetoothStatus.available
+    hoverEnabled: !Config.options.bar.tooltips.clickToShow
+    acceptedButtons: Qt.LeftButton | Qt.RightButton
+    cursorShape: Qt.PointingHandCursor
+    implicitWidth: vertical
+        ? Appearance.sizes.verticalBarWidth
+        : Math.max(contentLoader.item?.implicitWidth ?? 0, Appearance.font.pixelSize.larger) + 8
+    implicitHeight: vertical
+        ? Math.max(contentLoader.item?.implicitHeight ?? 0, Appearance.font.pixelSize.larger)
+        : Appearance.sizes.barHeight
+
+    onClicked: mouse => {
+        if (mouse.button === Qt.RightButton) {
+            GlobalStates.requestBluetoothDialog();
+        } else {
+            BluetoothStatus.togglePower();
+        }
+    }
+
+    Loader {
+        id: contentLoader
+        anchors.centerIn: parent
+        sourceComponent: root.vertical ? columnContent : rowContent
+    }
+
+    Component {
+        id: rowContent
+
+        RowLayout {
+            spacing: 4
+
+            MaterialSymbol {
+                Layout.alignment: Qt.AlignVCenter
+                text: root.stateIcon
+                iconSize: Appearance.font.pixelSize.larger
+                color: root.isMaterial
+                    ? Appearance.colors.colOnPrimaryContainer
+                    : Appearance.colors.colOnLayer1
+            }
+
+            StyledText {
+                Layout.alignment: Qt.AlignVCenter
+                visible: root.hasBattery && !root.veryConstrained
+                font.pixelSize: Appearance.font.pixelSize.small
+                font.features: { "tnum": 1 }
+                color: root.isLow
+                    ? Appearance.colors.colError
+                    : root.isMaterial
+                        ? Appearance.colors.colOnPrimaryContainer
+                        : Appearance.colors.colOnLayer1
+                text: root.percentageText
+            }
+        }
+    }
+
+    Component {
+        id: columnContent
+
+        ColumnLayout {
+            spacing: -2
+
+            MaterialSymbol {
+                Layout.alignment: Qt.AlignHCenter
+                text: root.stateIcon
+                iconSize: Appearance.font.pixelSize.larger
+                color: root.isMaterial
+                    ? Appearance.colors.colOnPrimaryContainer
+                    : Appearance.colors.colOnLayer1
+            }
+
+            StyledText {
+                Layout.alignment: Qt.AlignHCenter
+                visible: root.hasBattery
+                font.pixelSize: Appearance.font.pixelSize.smallest
+                font.features: { "tnum": 1 }
+                color: root.isLow
+                    ? Appearance.colors.colError
+                    : root.isMaterial
+                        ? Appearance.colors.colOnPrimaryContainer
+                        : Appearance.colors.colOnLayer1
+                text: root.percentageText
+            }
+        }
+    }
+
+    BluetoothPopup {
+        id: bluetoothPopup
+        hoverTarget: root
+    }
+}

--- a/modules/ii/bar/BluetoothPopup.qml
+++ b/modules/ii/bar/BluetoothPopup.qml
@@ -1,0 +1,121 @@
+import qs.services
+import qs.modules.common
+import qs.modules.common.widgets
+import QtQuick
+import QtQuick.Layouts
+
+StyledPopup {
+    id: root
+
+    function deviceType(device) {
+        switch (Icons.getBluetoothDeviceMaterialSymbol(device?.icon || "")) {
+        case "headphones": return Translation.tr("Headphones")
+        case "earbuds": return Translation.tr("Earbuds")
+        case "speaker": return Translation.tr("Speaker")
+        case "keyboard": return Translation.tr("Keyboard")
+        case "mouse": return Translation.tr("Mouse")
+        case "gamepad": return Translation.tr("Game controller")
+        case "phone": return Translation.tr("Phone")
+        case "tablet": return Translation.tr("Tablet")
+        case "computer": return Translation.tr("Computer")
+        case "printer": return Translation.tr("Printer")
+        default: return Translation.tr("Bluetooth device")
+        }
+    }
+
+    function hasBattery(device) {
+        return device?.batteryAvailable && Number.isFinite(Number(device?.battery))
+    }
+
+    ColumnLayout {
+        id: contentLayout
+        implicitWidth: 280
+        spacing: 8
+
+        Rectangle {
+            visible: BluetoothStatus.connectedDevices.length === 0
+            implicitWidth: 280
+            implicitHeight: visible ? emptyText.implicitHeight + 24 : 0
+            radius: Appearance.rounding.normal
+            color: Appearance.colors.colLayer1Base
+
+            StyledText {
+                id: emptyText
+                anchors.centerIn: parent
+                color: Appearance.colors.colOnSurfaceVariant
+                text: BluetoothStatus.enabled
+                    ? Translation.tr("No connected devices")
+                    : Translation.tr("Bluetooth is off")
+            }
+        }
+
+        Repeater {
+            model: BluetoothStatus.connectedDevices
+
+            delegate: Rectangle {
+                required property var modelData
+                implicitWidth: 280
+                implicitHeight: cardContent.implicitHeight + 24
+                radius: Appearance.rounding.normal
+                color: Appearance.colors.colSurfaceContainerLow
+
+                ColumnLayout {
+                    id: cardContent
+                    anchors {
+                        horizontalCenter: parent.horizontalCenter
+                        top: parent.top
+                        topMargin: 16
+                    }
+                    width: parent.width - 32
+                    spacing: 4
+
+                    StyledText {
+                        Layout.fillWidth: true
+                        text: modelData?.name || Translation.tr("Unknown device")
+                        font.pixelSize: Appearance.font.pixelSize.normal
+                        font.weight: Font.Medium
+                        color: Appearance.colors.colOnSurface
+                        elide: Text.ElideRight
+                    }
+
+                    StyledText {
+                        Layout.fillWidth: true
+                        text: `${root.deviceType(modelData)} · ${Translation.tr("Connected")}`
+                        font.pixelSize: Appearance.font.pixelSize.smaller
+                        color: Appearance.colors.colOnSurfaceVariant
+                        opacity: 0.7
+                        elide: Text.ElideRight
+                    }
+
+                    RowLayout {
+                        implicitWidth: parent.width
+                        spacing: 8
+
+                        MaterialShapeWrappedMaterialSymbol {
+                            Layout.alignment: Qt.AlignVCenter
+                            shape: MaterialShape.Shape.Circle
+                            text: Icons.getBluetoothDeviceMaterialSymbol(modelData?.icon || "")
+                            iconSize: Appearance.font.pixelSize.large
+                            implicitSize: Appearance.font.pixelSize.hugeass * 2
+                            color: Appearance.colors.colPrimaryContainer
+                            colSymbol: Appearance.colors.colPrimary
+                        }
+
+                        Item { Layout.fillWidth: true }
+
+                        StyledText {
+                            visible: root.hasBattery(modelData)
+                            Layout.alignment: Qt.AlignVCenter
+                            text: `${Math.round(Number(modelData.battery) * 100)}%`
+                            font.pixelSize: Appearance.font.pixelSize.hugeass * 2
+                            font.weight: Font.DemiBold
+                            font.features: { "tnum": 1 }
+                            color: Appearance.colors.colPrimary
+                        }
+                    }
+                }
+
+            }
+        }
+    }
+}

--- a/modules/ii/bar/BluetoothPopup.qml
+++ b/modules/ii/bar/BluetoothPopup.qml
@@ -93,7 +93,7 @@ StyledPopup {
 
                         MaterialShapeWrappedMaterialSymbol {
                             Layout.alignment: Qt.AlignVCenter
-                            shape: MaterialShape.Shape.Circle
+                            shape: MaterialShape.Shape.ClamShell
                             text: Icons.getBluetoothDeviceMaterialSymbol(modelData?.icon || "")
                             iconSize: Appearance.font.pixelSize.large
                             implicitSize: Appearance.font.pixelSize.hugeass * 2

--- a/modules/ii/bar/SystemIcons.qml
+++ b/modules/ii/bar/SystemIcons.qml
@@ -52,7 +52,7 @@ Item {
             onLoaded: item.color = root.isMaterial ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer1
         }
         MaterialSymbol {
-            text: Network.materialSymbol
+            text: Network.ethernet ? "network_wifi" : Network.materialSymbol
             iconSize: Appearance.font.pixelSize.larger
             color: root.isMaterial ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer1
         }

--- a/modules/ii/settings/pages/BarConfig.qml
+++ b/modules/ii/settings/pages/BarConfig.qml
@@ -47,6 +47,7 @@ ContentPage {
         { id: "utilButtons",       name: Translation.tr("Util Buttons"),         icon: "toggle_on" },
         { id: "sysTray",           name: Translation.tr("Tray"),                 icon: "inbox" },
         { id: "batteryIndicator",  name: Translation.tr("Battery"),              icon: "battery_android_frame_full" },
+        { id: "bluetooth",         name: Translation.tr("Bluetooth"),            icon: "bluetooth" },
         { id: "activeWindow",      name: Translation.tr("Active Window"),        icon: "subtitles" },
         { id: "powerButton",       name: Translation.tr("Power Button"),         icon: "power_settings_new" },
         { id: "updatesCount",      name: Translation.tr("Updates"),              icon: "deployed_code_update" },

--- a/modules/ii/sidebarRight/SidebarRightContent.qml
+++ b/modules/ii/sidebarRight/SidebarRightContent.qml
@@ -51,6 +51,12 @@ Item {
 
     Connections {
         target: GlobalStates
+        function onRequestBluetoothDialog() {
+            if (!BluetoothStatus.available) return;
+            root.showBluetoothDialog = true;
+            GlobalStates.sidebarRightOpen = true;
+        }
+
         function onSidebarRightOpenChanged() {
             if (!GlobalStates.sidebarRightOpen) {
                 root.showWifiDialog = false;
@@ -361,11 +367,13 @@ Item {
         shownPropertyString: "showBluetoothDialog"
         dialog: BluetoothDialog {}
         onShownChanged: {
+            const adapter = Bluetooth.defaultAdapter;
+            if (!adapter) return;
             if (!shown) {
-                Bluetooth.defaultAdapter.discovering = false;
+                adapter.discovering = false;
             } else {
-                Bluetooth.defaultAdapter.enabled = true;
-                Bluetooth.defaultAdapter.discovering = true;
+                adapter.enabled = true;
+                adapter.discovering = true;
             }
         }
     }

--- a/modules/ii/sidebarRight/bluetoothDevices/BluetoothDeviceItem.qml
+++ b/modules/ii/sidebarRight/bluetoothDevices/BluetoothDeviceItem.qml
@@ -92,10 +92,12 @@ DialogListItem {
 
                 buttonText: p ? Translation.tr("Forget") : Translation.tr("Always connect")
                 onClicked: {
-                    if (root.device?.paired) {
-                        root.device?.forget();
+                    const device = root.device;
+                    if (!device) return;
+                    if (device.paired) {
+                        device.forget();
                     } else {
-                        root.device?.pair();
+                        device.pair();
                     }
                 }
             }
@@ -103,10 +105,12 @@ DialogListItem {
                 buttonText: root.device?.connected ? Translation.tr("Disconnect") : Translation.tr("Connect")
 
                 onClicked: {
-                    if (root.device?.connected) {
-                        root.device.disconnect();
+                    const device = root.device;
+                    if (!device) return;
+                    if (device.connected) {
+                        device.disconnect();
                     } else {
-                        root.device.connect();
+                        device.connect();
                     }
                 }
             }

--- a/modules/ii/sidebarRight/quickToggles/classicStyle/BluetoothToggle.qml
+++ b/modules/ii/sidebarRight/quickToggles/classicStyle/BluetoothToggle.qml
@@ -14,7 +14,7 @@ QuickToggleButton {
     toggled: BluetoothStatus.enabled
     buttonIcon: BluetoothStatus.connected ? "bluetooth_connected" : BluetoothStatus.enabled ? "bluetooth" : "bluetooth_disabled"
     onClicked: {
-        Bluetooth.defaultAdapter.enabled = !Bluetooth.defaultAdapter?.enabled
+        BluetoothStatus.togglePower()
     }
     altAction: () => {
         Quickshell.execDetached(["bash", "-c", `${Config.options.apps.bluetooth}`])

--- a/services/BluetoothStatus.qml
+++ b/services/BluetoothStatus.qml
@@ -11,8 +11,8 @@ Singleton {
 
     readonly property bool available: Bluetooth.adapters.values.length > 0
     readonly property bool enabled: Bluetooth.defaultAdapter?.enabled ?? false
-    readonly property BluetoothDevice firstActiveDevice: Bluetooth.defaultAdapter?.devices.values.find(device => device.connected) ?? null
-    readonly property int activeDeviceCount: Bluetooth.defaultAdapter?.devices.values.filter(device => device.connected).length ?? 0
+    readonly property BluetoothDevice firstActiveDevice: Bluetooth.devices.values.find(device => device.connected) ?? null
+    readonly property int activeDeviceCount: Bluetooth.devices.values.filter(device => device.connected).length
     readonly property bool connected: Bluetooth.devices.values.some(d => d.connected)
 
     function sortFunction(a, b) {
@@ -29,9 +29,24 @@ Singleton {
     property list<var> connectedDevices: Bluetooth.devices.values.filter(d => d.connected).sort(sortFunction)
     property list<var> pairedButNotConnectedDevices: Bluetooth.devices.values.filter(d => d.paired && !d.connected).sort(sortFunction)
     property list<var> unpairedDevices: Bluetooth.devices.values.filter(d => !d.paired && !d.connected).sort(sortFunction)
+    readonly property list<var> connectedBatteryDevices: connectedDevices.filter(device => device.batteryAvailable && Number.isFinite(Number(device.battery)))
+    readonly property var primaryConnectedDevice: firstActiveDevice ?? connectedDevices[0] ?? null
+    readonly property var primaryBatteryDevice: hasBattery(primaryConnectedDevice)
+        ? primaryConnectedDevice
+        : connectedBatteryDevices[0] ?? null
     property list<var> friendlyDeviceList: [
         ...connectedDevices,
         ...pairedButNotConnectedDevices,
         ...unpairedDevices
     ]
+
+    function hasBattery(device): bool {
+        return !!device && device.batteryAvailable && Number.isFinite(Number(device.battery));
+    }
+
+    function togglePower() {
+        const adapter = Bluetooth.defaultAdapter;
+        if (!adapter) return;
+        adapter.enabled = !adapter.enabled;
+    }
 }


### PR DESCRIPTION
## Summary

- Add a Bluetooth bar module with battery-first connected-device presentation.
- Reuse Quickshell.Bluetooth through BluetoothStatus and existing Material icon mapping.
- Add device-type-aware icons, primary-device selection, battery fallback, and unavailable-device safety.
- Add compact hover cards for connected devices with horizontal and vertical bar support.
- Integrate the module with existing bar configuration, toggles, and Bluetooth dialog behavior.

## Validation

- git diff --check passed.
- Runtime validation performed with the connected Rockerz 411 and INFINIX 30I: bar visibility, device icons, battery values, hover popup activation, compact popup geometry, and multi-device cards were observed on the running desktop.
- The installed qmllint binary (version 1.0) exited 255 without diagnostics in this environment; this is reported rather than treated as a passing lint result.

The PR contains only Bluetooth source files; unrelated WorldClock and ActiveWindow changes and all documentation files are excluded.