### PR TITLE
Use vertical wallpaper on HDMI-A-2 monitor

### DIFF
--- a/modules/common/Config.qml
+++ b/modules/common/Config.qml
@@ -373,6 +373,7 @@ Singleton {
                 }
                 property list<string> screenList: [] 
                 property string wallpaperPath: ""
+                property string verticalWallpaperPath: ""
                 property bool centeredWallpaper: false
                 property string centeredWallpaperShape: "Cookie7Sided"
                 property int centeredWallpaperSize: 400

--- a/modules/ii/background/Background.qml
+++ b/modules/ii/background/Background.qml
@@ -410,7 +410,9 @@ Variants {
 
                 StyledImage {
                     anchors.fill: parent
-                    source: bgRoot.wallpaperPath
+                    source: (bgRoot.screen.name === "HDMI-A-2" && Config.options.background.verticalWallpaperPath !== "")
+                        ? Config.options.background.verticalWallpaperPath
+                        : bgRoot.wallpaperPath
                     fillMode: Image.PreserveAspectCrop
                     cache: false
                     antialiasing: true


### PR DESCRIPTION
## Summary
- Add a `verticalWallpaperPath` config option under `background`
- Use it for the centered wallpaper `StyledImage` when the screen is `HDMI-A-2`, falling back to the normal `wallpaperPath` for all other monitors

## Test plan
- [ ] Set `verticalWallpaperPath` in config and confirm the HDMI-A-2 output shows it
- [ ] Confirm other monitors still use `wallpaperPath` unchanged