### PR TITLE
fix(hyprland): set disabled = true instead of mode = "disabled" in monitor config

### DIFF
--- a/modules/common/models/hyprland/MonitorConfigOption.qml
+++ b/modules/common/models/hyprland/MonitorConfigOption.qml
@@ -20,7 +20,7 @@ NestableObject {
 
     function _buildLuaLine(m) {
         if (m.disabled)
-            return `hl.monitor({ output = "${m.name}", mode = "disabled" })`
+            return `hl.monitor({ output = "${m.name}", disabled = true })`
 
         const pos = `${m.x}x${m.y}`
         let line = `hl.monitor({ output = "${m.name}", mode = "${m.currentMode}", position = "${pos}", scale = ${m.scale}`


### PR DESCRIPTION
### Summary
    Updates `MonitorConfigOption.qml` to output `disabled = true` instead of `mode = "disabled"` when saving disabled monitor configurations to `~/.config/hypr/monitors.lua`.

### Changes
- In `_buildLuaLine(m)`, changed the return statement for disabled monitors from:

```lua
  hl.monitor({ output = "<name>", mode = "disabled" })

to:

  hl.monitor({ output = "<name>", disabled = true })