### PR TITLE
fix : correct primaryPaletteKeyColor typo in color script

### DIFF
--- a/scripts/colors/generate_colors_material.py
+++ b/scripts/colors/generate_colors_material.py
@@ -137,7 +137,7 @@ if args.termscheme is not None:
         json_termscheme = f.read()
     term_source_colors = json.loads(json_termscheme)['dark' if darkmode else 'light']
 
-    primary_color_argb = hex_to_argb(material_colors['primary_paletteKeyColor'])
+    primary_color_argb = hex_to_argb(material_colors['primaryPaletteKeyColor'])
     for color, val in term_source_colors.items():
         if(args.scheme == 'monochrome') :
             term_colors[color] = val


### PR DESCRIPTION
## Problem

`scripts/colors/generate_colors_material.py` crashes with:

KeyError: 'primary_paletteKeyColor'

whenever it's called with `--termscheme` (the default path via `switchwall.sh`
when terminal theming is enabled).

## Root cause

`material_colors` is populated from `vars(MaterialDynamicColors).keys()`, and
materialyoucolor's `MaterialDynamicColors` exposes this attribute as
`primaryPaletteKeyColor` (camelCase, no underscore). Line 140 looks it up as
`primary_paletteKeyColor` — an extra underscore — which never matches, so the
lookup raises `KeyError` and the script exits before reaching its final print
loop.

## Downstream impact

Because the script exits early, `material_colors.scss` is written empty.
`applycolor.sh` reads that file to build its find/replace list for terminal
theme templates (e.g. `kitty-theme.conf`); with an empty list, the substitution
loop runs zero times, so the template gets copied to
`~/.local/state/quickshell/user/generated/terminal/kitty-theme.conf` verbatim —
with literal `$term0`, `$primary`, etc. placeholders still in it, which Kitty
then fails to parse as valid colors. Any user with terminal theming enabled
(the default) hits a broken terminal theme and an unhandled Python traceback
on every wallpaper/color change.

## Fix

One-line change: use the correct camelCase key,
`material_colors['primaryPaletteKeyColor']`.

## Testing

Verified `primaryPaletteKeyColor` is the actual attribute name by inspecting
`materialyoucolor.dynamiccolor.material_dynamic_colors.MaterialDynamicColors`
directly. Confirmed `generate_colors_material.py --termscheme ...` runs to
completion after the fix, `material_colors.scss` is populated, and
`applycolor.sh` correctly substitutes real hex values into
`kitty-theme.conf`.