### PR TITLE
feat(sidebarLeft): add pinboard widget for pinned notes & images

### DIFF
--- a/modules/common/Config.qml
+++ b/modules/common/Config.qml
@@ -701,6 +701,9 @@ Singleton {
                     property bool enable: false
                     property int delay: 300 // Delay before sending request. Reduces (potential) rate limits and lag.
                 }
+                property JsonObject pinboard: JsonObject {
+                    property bool enable: true
+                }
                 property JsonObject media: JsonObject {
                     property bool enable: true
                     property bool artColors: false

--- a/modules/common/Directories.qml
+++ b/modules/common/Directories.qml
@@ -34,6 +34,8 @@ Singleton {
     property string shellConfigName: "config.json"
     property string shellConfigPath: `${Directories.shellConfig}/${Directories.shellConfigName}`
 	property string todoPath: FileUtils.trimFileProtocol(`${Directories.state}/user/todo.json`)
+	property string pinboardPath: FileUtils.trimFileProtocol(`${Directories.state}/user/pinboard.json`)
+	property string pinboardImages: FileUtils.trimFileProtocol(`${Directories.state}/user/pinboard_images`)
 	property string notesPath: FileUtils.trimFileProtocol(`${Directories.state}/user/notes.txt`)
     property string desktopNotesPath: FileUtils.trimFileProtocol(`${Directories.state}/user/desktopnotes.txt`)
 	property string conflictCachePath: FileUtils.trimFileProtocol(`${Directories.cache}/conflict-killer`)
@@ -65,6 +67,7 @@ Singleton {
         Quickshell.execDetached(["bash", "-c", `rm -rf '${latexOutput}'; mkdir -p '${latexOutput}'`])
         Quickshell.execDetached(["bash", "-c", `rm -rf '${cliphistDecode}'; mkdir -p '${cliphistDecode}'`])
         Quickshell.execDetached(["mkdir", "-p", `${aiChats}`])
+        Quickshell.execDetached(["mkdir", "-p", `${pinboardImages}`])
         Quickshell.execDetached(["mkdir", "-p", `${userActions}`])
         Quickshell.execDetached(["rm", "-rf", `${tempImages}`])
     }

--- a/modules/common/widgets/PagePlaceholder.qml
+++ b/modules/common/widgets/PagePlaceholder.qml
@@ -27,6 +27,7 @@ Item {
 
     ColumnLayout {
         anchors.centerIn: parent
+        width: Math.max(0, Math.min(root.width - 40, 400))
         spacing: 5
 
         MaterialShapeWrappedMaterialSymbol {
@@ -40,6 +41,8 @@ Item {
             id: widgetNameText
             visible: title !== ""
             Layout.alignment: Qt.AlignHCenter
+            Layout.fillWidth: true
+            wrapMode: Text.Wrap
             font {
                 family: Appearance.font.family.title
                 pixelSize: Appearance.font.pixelSize.larger
@@ -54,7 +57,7 @@ Item {
             Layout.fillWidth: true
             font.pixelSize: Appearance.font.pixelSize.small
             color: Appearance.m3colors.m3outline
-            horizontalAlignment: Text.AlignLeft
+            horizontalAlignment: Text.AlignHCenter
             wrapMode: Text.Wrap
         }
     }

--- a/modules/ii/sidebarLeft/PinboardWidget.qml
+++ b/modules/ii/sidebarLeft/PinboardWidget.qml
@@ -1,0 +1,822 @@
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.modules.common.functions
+import qs.services
+import qs.modules.ii.sidebarLeft.pinboard
+import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
+import Quickshell
+import Quickshell.Io
+
+Item {
+    id: root
+
+    Component.onCompleted: {
+        Pinboard.refresh();
+    }
+
+    // Pending draft properties
+    property string pendingImagePath: ""
+    property bool isPasting: false
+
+    // Helpers to determine item-by-item navigation states
+    property int totalPins: Pinboard.list.length
+    property int currentVisibleIndex: {
+        if (pinListView.count === 0) return 0;
+        const idx = pinListView.indexAt(10, pinListView.contentY + pinListView.spacing + 4);
+        return idx >= 0 ? idx : 0;
+    }
+    readonly property bool canScrollUp: pinListView.contentY > 4
+    readonly property bool canScrollDown: pinListView.contentY < Math.max(0, pinListView.contentHeight - pinListView.height - 4)
+
+    function addCurrentPin() {
+        const text = noteInputArea.text.trim();
+        const image = root.pendingImagePath.trim();
+        if (text.length === 0 && image.length === 0) return;
+
+        const _newId = Pinboard.addPin(text, image);
+        noteInputArea.text = "";
+        root.pendingImagePath = "";
+        scrollToItem(0);
+    }
+
+    function scrollToItem(index: int) {
+        if (index < 0 || index >= pinListView.count) return;
+        pinListView.currentIndex = index;
+        const item = pinListView.itemAtIndex(index);
+        const maxY = Math.max(0, pinListView.contentHeight - pinListView.height);
+        if (item) {
+            const targetY = Math.max(0, Math.min(item.y, maxY));
+            scrollAnimation.stop();
+            scrollAnimation.to = targetY;
+            scrollAnimation.restart();
+        } else {
+            pinListView.positionViewAtIndex(index, ListView.Beginning);
+        }
+    }
+
+    function scrollNextItem() {
+        if (pinListView.count === 0) return;
+        const cur = root.currentVisibleIndex;
+        const next = Math.min(pinListView.count - 1, cur + 1);
+        scrollToItem(next);
+    }
+
+    function scrollPrevItem() {
+        if (pinListView.count === 0) return;
+        const cur = root.currentVisibleIndex;
+        const curItem = pinListView.itemAtIndex(cur);
+        let prev = cur - 1;
+        if (curItem && pinListView.contentY > curItem.y + 4) {
+            prev = cur;
+        }
+        prev = Math.max(0, prev);
+        scrollToItem(prev);
+    }
+
+    // Keyboard navigation
+    Keys.onPressed: (event) => {
+        if (event.key === Qt.Key_Down || event.key === Qt.Key_PageDown) {
+            scrollNextItem();
+            event.accepted = true;
+        } else if (event.key === Qt.Key_Up || event.key === Qt.Key_PageUp) {
+            scrollPrevItem();
+            event.accepted = true;
+        }
+    }
+
+    // Smooth scroll animation
+    NumberAnimation {
+        id: scrollAnimation
+        target: pinListView
+        property: "contentY"
+        duration: Appearance.animation.elementMove.duration
+        easing.type: Appearance.animation.elementMove.type
+        easing.bezierCurve: Appearance.animation.elementMove.bezierCurve
+    }
+
+    // File picker process for images
+    Process {
+        id: pickImageProc
+        command: ["bash", "-c", `
+            if command -v zenity > /dev/null 2>&1; then
+                zenity --file-selection --title="Select Image to Pin" --file-filter="Images | *.png *.jpg *.jpeg *.webp *.gif *.bmp *.svg *.avif" 2>/dev/null
+            elif command -v kdialog > /dev/null 2>&1; then
+                kdialog --getopenfilename "$HOME" "Images (*.png *.jpg *.jpeg *.webp *.gif *.bmp *.svg *.avif)" 2>/dev/null
+            fi
+        `]
+        property string buffer: ""
+        stdout: SplitParser {
+            onRead: (data) => {
+                pickImageProc.buffer += data;
+            }
+        }
+        onExited: (exitCode, exitStatus) => {
+            if (exitCode === 0) {
+                const chosenPath = pickImageProc.buffer.trim();
+                if (chosenPath.length > 0) {
+                    root.pendingImagePath = chosenPath;
+                }
+            }
+            pickImageProc.buffer = "";
+        }
+    }
+
+    // Clipboard paste process
+    Process {
+        id: pasteProc
+        property string buffer: ""
+        command: ["bash", "-c", `
+            PIN_DIR="${Directories.pinboardImages}"
+            mkdir -p "$PIN_DIR"
+            if wl-paste --list-types 2>/dev/null | grep -qE '^image/'; then
+                TARGET="$PIN_DIR/pin_clip_$(date +%s%N).png"
+                if wl-paste -t image/png > "$TARGET" 2>/dev/null; then
+                    echo "IMAGE:$TARGET"
+                    exit 0
+                fi
+            fi
+            TEXT="$(wl-paste --no-newline 2>/dev/null)"
+            if [ -n "$TEXT" ]; then
+                CLEAN="\${TEXT#file://}"
+                if [ -f "$CLEAN" ]; then
+                    EXT="\${CLEAN##*.}"
+                    case "\${EXT,,}" in
+                        png|jpg|jpeg|webp|gif|bmp|svg|avif)
+                            echo "IMAGE:$CLEAN"
+                            exit 0
+                            ;;
+                    esac
+                fi
+                echo "TEXT:$TEXT"
+                exit 0
+            fi
+            exit 1
+        `]
+        stdout: SplitParser {
+            onRead: (data) => {
+                pasteProc.buffer += data;
+            }
+        }
+        onExited: (exitCode, exitStatus) => {
+            root.isPasting = false;
+            if (exitCode === 0) {
+                const res = pasteProc.buffer.trim();
+                if (res.startsWith("IMAGE:")) {
+                    const img = res.slice(6).trim();
+                    root.pendingImagePath = img;
+                } else if (res.startsWith("TEXT:")) {
+                    const txt = res.slice(5);
+                    if (noteInputArea.text.length > 0) {
+                        noteInputArea.text += "\n" + txt;
+                    } else {
+                        noteInputArea.text = txt;
+                    }
+                }
+            }
+            pasteProc.buffer = "";
+        }
+    }
+
+    function triggerPaste() {
+        if (pasteProc.running) return;
+        root.isPasting = true;
+        pasteProc.buffer = "";
+        pasteProc.running = true;
+    }
+
+    // Main layout
+    ColumnLayout {
+        anchors.fill: parent
+        spacing: 10
+
+        // Top: Navigation header for item-by-item browsing (when items exist)
+        RowLayout {
+            Layout.fillWidth: true
+            visible: Pinboard.list.length > 0
+            spacing: 6
+
+            MaterialSymbol {
+                text: "view_agenda"
+                iconSize: 15
+                color: Appearance.colors.colSubtext
+            }
+
+            StyledText {
+                text: Translation.tr("Pin %1 of %2").arg(root.currentVisibleIndex + 1).arg(Pinboard.list.length)
+                font.pixelSize: Appearance.font.pixelSize.smaller
+                color: Appearance.colors.colSubtext
+            }
+
+            Item { Layout.fillWidth: true }
+
+            // Scroll Up / Previous Item
+            RippleButton {
+                id: prevItemBtn
+                implicitWidth: 28
+                implicitHeight: 28
+                buttonRadius: Appearance.rounding.full
+                enabled: root.canScrollUp
+                opacity: enabled ? 1 : 0.3
+                colBackground: Appearance.colors.colLayer2
+                colBackgroundHover: Appearance.colors.colLayer2Hover
+
+                contentItem: MaterialSymbol {
+                    anchors.centerIn: parent
+                    text: "keyboard_arrow_up"
+                    iconSize: 18
+                    color: Appearance.colors.colOnLayer2
+                    horizontalAlignment: Text.AlignHCenter
+                }
+
+                StyledToolTip {
+                    extraVisibleCondition: prevItemBtn.hovered
+                    text: Translation.tr("Previous item (Wheel Up)")
+                }
+
+                onClicked: root.scrollPrevItem()
+            }
+
+            // Scroll Down / Next Item
+            RippleButton {
+                id: nextItemBtn
+                implicitWidth: 28
+                implicitHeight: 28
+                buttonRadius: Appearance.rounding.full
+                enabled: root.canScrollDown
+                opacity: enabled ? 1 : 0.3
+                colBackground: Appearance.colors.colLayer2
+                colBackgroundHover: Appearance.colors.colLayer2Hover
+
+                contentItem: MaterialSymbol {
+                    anchors.centerIn: parent
+                    text: "keyboard_arrow_down"
+                    iconSize: 18
+                    color: Appearance.colors.colOnLayer2
+                    horizontalAlignment: Text.AlignHCenter
+                }
+
+                StyledToolTip {
+                    extraVisibleCondition: nextItemBtn.hovered
+                    text: Translation.tr("Next item (Wheel Down)")
+                }
+
+                onClicked: root.scrollNextItem()
+            }
+        }
+
+        // Scrollable Pins View (fills remaining space)
+        Item {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            clip: true
+
+            // Empty state placeholder
+            PagePlaceholder {
+                shown: Pinboard.list.length === 0
+                icon: "push_pin"
+                title: Translation.tr("No pins yet")
+                description: Translation.tr("Add notes, attach images, paste from clipboard, or drop files here.")
+                shape: MaterialShape.Shape.Ghostish
+            }
+
+            // Item-by-item scrollable list view
+            ListView {
+                id: pinListView
+                anchors.fill: parent
+                visible: Pinboard.list.length > 0
+                spacing: 10
+                clip: true
+                cacheBuffer: 1500
+
+                property int draggingIndex: -1
+                property int targetIndex: -1
+                property real dragYOffset: 0
+                property real dragItemHeight: 0
+                property real dragStartContentMouseY: 0
+                property real dragCurrentViewportY: -1
+                readonly property bool isDragging: draggingIndex !== -1
+
+                // Snapping disabled during drag to prevent snap fighting
+                snapMode: isDragging ? ListView.NoSnap : ListView.SnapToItem
+                boundsBehavior: Flickable.StopAtBounds
+                interactive: !isDragging
+
+                ScrollBar.vertical: StyledScrollBar {}
+
+                model: ScriptModel {
+                    values: Pinboard.list
+                }
+
+                function updateDragPosition(currentViewportY: real) {
+                    if (!isDragging) return;
+                    dragCurrentViewportY = currentViewportY;
+
+                    const currentContentMouseY = contentY + currentViewportY;
+                    const delta = currentContentMouseY - dragStartContentMouseY;
+                    dragYOffset = delta;
+
+                    // Determine target index based on center of dragged item in content coordinates
+                    const curItem = itemAtIndex(draggingIndex);
+                    const baseItemY = curItem ? curItem.y : 0;
+                    const draggedCenterY = baseItemY + dragYOffset + (dragItemHeight / 2);
+                    const clampedY = Math.max(5, Math.min(contentHeight - 5, draggedCenterY));
+
+                    let hitIndex = indexAt(width / 2, clampedY);
+                    if (hitIndex === -1) {
+                        if (draggedCenterY <= 10) hitIndex = 0;
+                        else if (draggedCenterY >= contentHeight - 10) hitIndex = count - 1;
+                    }
+                    if (hitIndex !== -1 && hitIndex >= 0 && hitIndex < count) {
+                        targetIndex = hitIndex;
+                    }
+                }
+
+                Timer {
+                    id: autoScrollTimer
+                    interval: 16
+                    repeat: true
+                    running: pinListView.isDragging
+                    onTriggered: {
+                        if (!pinListView.isDragging || pinListView.dragCurrentViewportY < -100) return;
+
+                        const topEdge = 45;
+                        const bottomEdge = pinListView.height - 45;
+                        const vy = pinListView.dragCurrentViewportY;
+                        const maxScroll = Math.max(0, pinListView.contentHeight - pinListView.height);
+
+                        if (vy < topEdge && pinListView.contentY > 0) {
+                            const speed = Math.max(3, Math.min(16, (topEdge - vy) * 0.4));
+                            pinListView.contentY = Math.max(0, pinListView.contentY - speed);
+                            pinListView.updateDragPosition(pinListView.dragCurrentViewportY);
+                        } else if (vy > bottomEdge && pinListView.contentY < maxScroll) {
+                            const speed = Math.max(3, Math.min(16, (vy - bottomEdge) * 0.4));
+                            pinListView.contentY = Math.min(maxScroll, pinListView.contentY + speed);
+                            pinListView.updateDragPosition(pinListView.dragCurrentViewportY);
+                        }
+                    }
+                }
+
+                delegate: Item {
+                    id: dragDelegate
+                    required property var modelData
+                    required property int index
+
+                    width: pinListView.width
+                    height: pinItem.implicitHeight
+
+                    readonly property bool isThisItemDragging: pinListView.draggingIndex === dragDelegate.index
+
+                    // Calculate shift for items when another item is being dragged
+                    readonly property real shiftY: {
+                        if (pinListView.draggingIndex === -1 || isThisItemDragging) return 0;
+                        const from = pinListView.draggingIndex;
+                        const to = pinListView.targetIndex;
+                        if (from < to) {
+                            // Dragging downwards: items between from+1 and to shift UP
+                            if (dragDelegate.index > from && dragDelegate.index <= to) {
+                                return -pinListView.dragItemHeight - pinListView.spacing;
+                            }
+                        } else if (from > to) {
+                            // Dragging upwards: items between to and from-1 shift DOWN
+                            if (dragDelegate.index >= to && dragDelegate.index < from) {
+                                return pinListView.dragItemHeight + pinListView.spacing;
+                            }
+                        }
+                        return 0;
+                    }
+
+                    // Lift dragged card above others
+                    z: isThisItemDragging ? 100 : 1
+
+                    // The visual card
+                    PinboardItem {
+                        id: pinItem
+                        width: dragDelegate.width
+                        pinData: dragDelegate.modelData
+                        pinIndex: dragDelegate.index
+                        isDragging: dragDelegate.isThisItemDragging
+
+                        // When dragging, follow mouse offset directly
+                        y: dragDelegate.isThisItemDragging ? pinListView.dragYOffset : 0
+
+                        // Apply shift when other items are being dragged
+                        transform: Translate {
+                            y: dragDelegate.shiftY
+                            Behavior on y {
+                                NumberAnimation {
+                                    duration: Appearance.animation.elementMoveFast.duration
+                                    easing.type: Easing.OutCubic
+                                }
+                            }
+                        }
+                    }
+
+                    // Drag handle MouseArea covering the full height of the dedicated left strip
+                    MouseArea {
+                        id: dragHandleArea
+                        anchors {
+                            top: parent.top
+                            bottom: parent.bottom
+                            left: parent.left
+                        }
+                        width: 36
+                        preventStealing: true
+                        hoverEnabled: true
+                        cursorShape: (pinListView.draggingIndex === dragDelegate.index) ? Qt.ClosedHandCursor : Qt.OpenHandCursor
+
+                        onEntered: pinItem.isHandleHovered = true
+                        onExited: {
+                            if (pinListView.draggingIndex !== dragDelegate.index) {
+                                pinItem.isHandleHovered = false;
+                            }
+                        }
+
+                        onPressed: (mouse) => {
+                            pinItem.isHandleHovered = true;
+                            const viewPoint = dragHandleArea.mapToItem(pinListView, mouse.x, mouse.y);
+                            pinListView.dragCurrentViewportY = viewPoint.y;
+                            pinListView.dragStartContentMouseY = pinListView.contentY + viewPoint.y;
+                            pinListView.dragItemHeight = dragDelegate.height;
+                            pinListView.draggingIndex = dragDelegate.index;
+                            pinListView.targetIndex = dragDelegate.index;
+                            pinListView.dragYOffset = 0;
+                        }
+
+                        onPositionChanged: (mouse) => {
+                            if (pinListView.draggingIndex !== dragDelegate.index) return;
+                            const viewPoint = dragHandleArea.mapToItem(pinListView, mouse.x, mouse.y);
+                            pinListView.updateDragPosition(viewPoint.y);
+                        }
+
+                        onReleased: {
+                            pinItem.isHandleHovered = false;
+                            pinListView.dragCurrentViewportY = -1;
+                            if (pinListView.draggingIndex === dragDelegate.index) {
+                                const from = pinListView.draggingIndex;
+                                const to = pinListView.targetIndex;
+                                pinListView.draggingIndex = -1;
+                                pinListView.targetIndex = -1;
+                                pinListView.dragYOffset = 0;
+                                if (from !== -1 && to !== -1 && from !== to) {
+                                    Pinboard.movePin(from, to);
+                                }
+                            }
+                        }
+
+                        onCanceled: {
+                            pinItem.isHandleHovered = false;
+                            pinListView.dragCurrentViewportY = -1;
+                            pinListView.draggingIndex = -1;
+                            pinListView.targetIndex = -1;
+                            pinListView.dragYOffset = 0;
+                        }
+
+                        StyledToolTip {
+                            extraVisibleCondition: dragHandleArea.containsMouse && !pinListView.isDragging
+                            text: Translation.tr("Drag to rearrange")
+                        }
+                    }
+                }
+
+                // Wheel handler — disabled while dragging
+                WheelHandler {
+                    id: pinWheelHandler
+                    target: pinListView
+                    enabled: !pinListView.isDragging
+                    acceptedDevices: PointerDevice.Mouse | PointerDevice.TouchPad
+                    onWheel: (event) => {
+                        if (event.angleDelta.y < 0) {
+                            root.scrollNextItem();
+                        } else if (event.angleDelta.y > 0) {
+                            root.scrollPrevItem();
+                        }
+                        event.accepted = true;
+                    }
+                }
+            }
+        }
+
+        // Middle bar: item count + Clear All
+        Rectangle {
+            id: bottomBar
+            Layout.fillWidth: true
+            implicitHeight: 44
+            radius: Appearance.rounding.normal
+            color: Appearance.colors.colLayer2
+            border.width: 1
+            border.color: ColorUtils.transparentize(Appearance.colors.colOutlineVariant, 0.7)
+
+            RowLayout {
+                anchors { fill: parent; leftMargin: 12; rightMargin: 8 }
+                spacing: 8
+
+                MaterialSymbol {
+                    text: "push_pin"
+                    iconSize: 16
+                    color: Appearance.colors.colSubtext
+                }
+
+                StyledText {
+                    Layout.fillWidth: true
+                    text: Pinboard.list.length === 1
+                        ? Translation.tr("1 item pinned")
+                        : Translation.tr("%1 items pinned").arg(Pinboard.list.length)
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: Appearance.colors.colSubtext
+                }
+
+                RippleButton {
+                    id: clearAllButton
+                    enabled: Pinboard.list.length > 0
+                    opacity: enabled ? 1 : 0.4
+                    implicitHeight: 32
+                    horizontalPadding: 12
+                    buttonRadius: Appearance.rounding.full
+                    colBackground: ColorUtils.transparentize(Appearance.colors.colErrorContainer, 0.4)
+                    colBackgroundHover: Appearance.colors.colErrorContainer
+                    colRipple: Appearance.colors.colError
+
+                    contentItem: RowLayout {
+                        spacing: 6
+                        MaterialSymbol {
+                            text: "delete_sweep"
+                            iconSize: 16
+                            color: clearAllButton.enabled ? Appearance.colors.colOnErrorContainer : Appearance.colors.colSubtext
+                        }
+                        StyledText {
+                            text: Translation.tr("Clear all")
+                            font.pixelSize: Appearance.font.pixelSize.smaller
+                            font.weight: Font.Medium
+                            color: clearAllButton.enabled ? Appearance.colors.colOnErrorContainer : Appearance.colors.colSubtext
+                        }
+                    }
+
+                    StyledToolTip {
+                        extraVisibleCondition: clearAllButton.hovered
+                        text: Translation.tr("Clear all pinned items")
+                    }
+
+                    onClicked: Pinboard.clearAll()
+                }
+            }
+        }
+
+        // Very Bottom: Input & Compose Card
+        Rectangle {
+            id: composeCard
+            Layout.fillWidth: true
+            implicitHeight: composeLayout.implicitHeight + 16
+            radius: Appearance.rounding.normal
+            color: Appearance.colors.colLayer2
+            border.width: 1
+            border.color: ColorUtils.transparentize(Appearance.colors.colOutlineVariant, 0.7)
+
+            ColumnLayout {
+                id: composeLayout
+                anchors { top: parent.top; left: parent.left; right: parent.right; margins: 8 }
+                spacing: 8
+
+                // Text Input Area
+                ScrollView {
+                    Layout.fillWidth: true
+                    implicitHeight: Math.min(90, Math.max(45, noteInputArea.contentHeight + 16))
+                    clip: true
+                    ScrollBar.vertical.policy: ScrollBar.AsNeeded
+
+                    StyledTextArea {
+                        id: noteInputArea
+                        anchors.fill: parent
+                        wrapMode: TextArea.Wrap
+                        placeholderText: Translation.tr("Write a note or paste image/text...")
+                        color: activeFocus ? Appearance.m3colors.m3onSurface : Appearance.m3colors.m3onSurfaceVariant
+                        background: null
+
+                        Keys.onReturnPressed: (event) => {
+                            if (event.modifiers === Qt.ControlModifier) {
+                                root.addCurrentPin();
+                                event.accepted = true;
+                            } else {
+                                event.accepted = false;
+                            }
+                        }
+
+                        Keys.onPressed: (event) => {
+                            if (event.modifiers === Qt.ControlModifier && event.key === Qt.Key_V) {
+                                root.triggerPaste();
+                                event.accepted = true;
+                            }
+                        }
+                    }
+                }
+
+                // Attached image chip preview
+                Rectangle {
+                    id: attachedImageChip
+                    visible: root.pendingImagePath.length > 0
+                    Layout.fillWidth: true
+                    implicitHeight: 44
+                    radius: Appearance.rounding.small
+                    color: Appearance.colors.colLayer1
+                    border.width: 1
+                    border.color: ColorUtils.transparentize(Appearance.colors.colOutlineVariant, 0.6)
+
+                    RowLayout {
+                        anchors { fill: parent; margins: 4 }
+                        spacing: 8
+
+                        Rectangle {
+                            implicitWidth: 36
+                            implicitHeight: 36
+                            radius: Appearance.rounding.verysmall
+                            color: "transparent"
+                            clip: true
+
+                            StyledImage {
+                                anchors.fill: parent
+                                source: root.pendingImagePath ? ("file://" + FileUtils.trimFileProtocol(root.pendingImagePath)) : ""
+                                fillMode: Image.PreserveAspectCrop
+                                asynchronous: true
+                            }
+                        }
+
+                        StyledText {
+                            Layout.fillWidth: true
+                            text: FileUtils.fileNameForPath(root.pendingImagePath)
+                            elide: Text.ElideMiddle
+                            font.pixelSize: Appearance.font.pixelSize.smaller
+                            color: Appearance.colors.colOnLayer1
+                        }
+
+                        RippleButton {
+                            implicitWidth: 28
+                            implicitHeight: 28
+                            buttonRadius: Appearance.rounding.full
+                            colBackground: "transparent"
+                            colBackgroundHover: Appearance.colors.colErrorContainer
+
+                            contentItem: MaterialSymbol {
+                                anchors.centerIn: parent
+                                text: "close"
+                                iconSize: 14
+                                color: Appearance.colors.colSubtext
+                                horizontalAlignment: Text.AlignHCenter
+                            }
+
+                            StyledToolTip { text: Translation.tr("Remove attachment") }
+                            onClicked: root.pendingImagePath = ""
+                        }
+                    }
+                }
+
+                // Action buttons toolbar
+                RowLayout {
+                    Layout.fillWidth: true
+                    spacing: 6
+
+                    RippleButton {
+                        id: attachImageBtn
+                        implicitHeight: 34
+                        horizontalPadding: 10
+                        buttonRadius: Appearance.rounding.small
+                        colBackground: Appearance.colors.colLayer1
+                        colBackgroundHover: Appearance.colors.colLayer1Hover
+
+                        contentItem: RowLayout {
+                            spacing: 6
+                            MaterialSymbol { text: "add_photo_alternate"; iconSize: 16; color: Appearance.colors.colOnLayer1 }
+                            StyledText { text: Translation.tr("Image"); font.pixelSize: Appearance.font.pixelSize.smaller; color: Appearance.colors.colOnLayer1 }
+                        }
+
+                        StyledToolTip {
+                            extraVisibleCondition: attachImageBtn.hovered
+                            text: Translation.tr("Attach an image file")
+                        }
+
+                        onClicked: {
+                            pickImageProc.running = false;
+                            pickImageProc.buffer = "";
+                            pickImageProc.running = true;
+                        }
+                    }
+
+                    RippleButton {
+                        id: pasteBtn
+                        implicitHeight: 34
+                        horizontalPadding: 10
+                        buttonRadius: Appearance.rounding.small
+                        colBackground: Appearance.colors.colLayer1
+                        colBackgroundHover: Appearance.colors.colLayer1Hover
+
+                        contentItem: RowLayout {
+                            spacing: 6
+                            MaterialSymbol { text: root.isPasting ? "hourglass_empty" : "content_paste"; iconSize: 16; color: Appearance.colors.colOnLayer1 }
+                            StyledText { text: Translation.tr("Paste"); font.pixelSize: Appearance.font.pixelSize.smaller; color: Appearance.colors.colOnLayer1 }
+                        }
+
+                        StyledToolTip {
+                            extraVisibleCondition: pasteBtn.hovered
+                            text: Translation.tr("Paste image or text from clipboard")
+                        }
+
+                        onClicked: root.triggerPaste()
+                    }
+
+                    Item { Layout.fillWidth: true }
+
+                    RippleButton {
+                        id: pinSubmitBtn
+                        implicitHeight: 34
+                        horizontalPadding: 14
+                        buttonRadius: Appearance.rounding.small
+                        enabled: noteInputArea.text.trim().length > 0 || root.pendingImagePath.length > 0
+                        opacity: enabled ? 1 : 0.4
+                        colBackground: pinSubmitBtn.enabled ? Appearance.colors.colPrimary : Appearance.colors.colLayer1
+                        colBackgroundHover: Appearance.colors.colPrimaryHover
+                        colRipple: Appearance.colors.colPrimaryActive
+
+                        contentItem: RowLayout {
+                            spacing: 6
+                            MaterialSymbol {
+                                text: "push_pin"
+                                iconSize: 16
+                                color: pinSubmitBtn.enabled ? Appearance.colors.colOnPrimary : Appearance.colors.colSubtext
+                            }
+                            StyledText {
+                                text: Translation.tr("Pin")
+                                font.weight: Font.Medium
+                                font.pixelSize: Appearance.font.pixelSize.small
+                                color: pinSubmitBtn.enabled ? Appearance.colors.colOnPrimary : Appearance.colors.colSubtext
+                            }
+                        }
+
+                        StyledToolTip {
+                            extraVisibleCondition: pinSubmitBtn.hovered
+                            text: Translation.tr("Add pin (Ctrl+Enter)")
+                        }
+
+                        onClicked: root.addCurrentPin()
+                    }
+                }
+            }
+        }
+    }
+
+    // Drag and Drop Area covering the pinboard
+    DropArea {
+        id: dropArea
+        anchors.fill: parent
+        keys: ["text/uri-list", "text/plain"]
+        onEntered: (drag) => { drag.accept(Qt.CopyAction); }
+        onDropped: (drop) => {
+            if (drop.hasUrls && drop.urls.length > 0) {
+                for (let i = 0; i < drop.urls.length; i++) {
+                    const clean = FileUtils.trimFileProtocol(drop.urls[i].toString());
+                    const ext = clean.split(".").pop().toLowerCase();
+                    const imageExts = ["png", "jpg", "jpeg", "webp", "gif", "bmp", "svg", "avif"];
+                    if (imageExts.indexOf(ext) !== -1) {
+                        Pinboard.addPin("", clean);
+                    } else {
+                        Pinboard.addPin(clean, "");
+                    }
+                }
+                root.scrollToItem(0);
+            } else if (drop.hasText && drop.text.length > 0) {
+                Pinboard.addPin(drop.text, "");
+                root.scrollToItem(0);
+            }
+        }
+    }
+
+    // Visual drop overlay indicator
+    Rectangle {
+        anchors.fill: parent
+        visible: dropArea.containsDrag
+        color: ColorUtils.transparentize(Appearance.colors.colPrimaryContainer, 0.2)
+        radius: Appearance.rounding.normal
+        border.width: 2
+        border.color: Appearance.colors.colPrimary
+        z: 999
+
+        ColumnLayout {
+            anchors.centerIn: parent
+            spacing: 8
+
+            MaterialSymbol {
+                Layout.alignment: Qt.AlignHCenter
+                text: "file_download"
+                iconSize: 48
+                color: Appearance.colors.colOnPrimaryContainer
+            }
+
+            StyledText {
+                Layout.alignment: Qt.AlignHCenter
+                text: Translation.tr("Drop image or text to pin")
+                font.pixelSize: Appearance.font.pixelSize.normal
+                font.weight: Font.Medium
+                color: Appearance.colors.colOnPrimaryContainer
+            }
+        }
+    }
+}

--- a/modules/ii/sidebarLeft/SidebarLeftContent.qml
+++ b/modules/ii/sidebarLeft/SidebarLeftContent.qml
@@ -14,11 +14,13 @@ Item {
     anchors.fill: parent
     property bool aiChatEnabled: Config.options.policies.ai !== 0
     property bool translatorEnabled: Config.options.sidebar.translator.enable
+    property bool pinboardEnabled: Config.options.sidebar.pinboard.enable
     property bool animeEnabled: Config.options.policies.weeb !== 0
     property bool animeCloset: Config.options.policies.weeb === 2
     property bool mediaEnabled: Config.options.sidebar.media.enable
     property var tabButtonList: [
         ...(root.aiChatEnabled ? [{"icon": "neurology", "name": Translation.tr("Intelligence")}] : []),
+        ...(root.pinboardEnabled ? [{"icon": "push_pin", "name": Translation.tr("Pinboard")}] : []),
         ...(root.translatorEnabled ? [{"icon": "translate", "name": Translation.tr("Translator")}] : []),
         ...(root.mediaEnabled ? [{"icon": "music_note", "name": Translation.tr("Media")}] : []),
         ...((root.animeEnabled && !root.animeCloset) ? [{"icon": "bookmark_heart", "name": Translation.tr("Anime")}] : [])
@@ -73,7 +75,7 @@ Item {
                 id: swipeView
                 anchors.fill: parent
                 spacing: 10
-                currentIndex: tabBar.currentIndex
+                currentIndex: verticalTabBar.currentIndex
 
                 clip: true
                 layer.enabled: true
@@ -87,9 +89,10 @@ Item {
 
                 contentChildren: [
                     ...(root.aiChatEnabled ? [aiChat.createObject()] : []),
+                    ...(root.pinboardEnabled ? [pinboard.createObject()] : []),
                     ...(root.translatorEnabled ? [translator.createObject()] : []),
                     ...(root.mediaEnabled ? [media.createObject()] : []),
-                    ...((root.tabButtonList.length === 0 || (!root.aiChatEnabled && !root.translatorEnabled && root.animeCloset)) ? [placeholder.createObject()] : []),
+                    ...((root.tabButtonList.length === 0 || (!root.aiChatEnabled && !root.translatorEnabled && !root.pinboardEnabled && root.animeCloset)) ? [placeholder.createObject()] : []),
                     ...(root.animeEnabled ? [anime.createObject()] : []),
                 ]
             }
@@ -98,6 +101,10 @@ Item {
         Component {
             id: aiChat
             AiChat {}
+        }
+        Component {
+            id: pinboard
+            PinboardWidget {}
         }
         Component {
             id: translator

--- a/modules/ii/sidebarLeft/pinboard/PinboardItem.qml
+++ b/modules/ii/sidebarLeft/pinboard/PinboardItem.qml
@@ -1,0 +1,269 @@
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.modules.common.functions
+import qs.services
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+
+Item {
+    id: root
+
+    property var pinData: null
+    property int pinIndex: 0
+    property bool isDragging: false
+    property bool isHandleHovered: false
+
+    readonly property string pinId: pinData?.id ?? ""
+    readonly property string pinContent: pinData?.content ?? ""
+    readonly property string pinImage: pinData?.image ?? ""
+    readonly property var pinCreatedAt: pinData?.createdAt ?? 0
+
+    width: ListView.view ? ListView.view.width : parent.width
+    implicitHeight: cardBackground.implicitHeight
+
+    // Feedback state for copy action
+    property bool copiedFeedback: false
+
+    Timer {
+        id: copiedTimer
+        interval: 1800
+        onTriggered: root.copiedFeedback = false
+    }
+
+    Rectangle {
+        id: cardBackground
+        anchors {
+            left: parent.left
+            right: parent.right
+            leftMargin: root.isDragging ? 2 : 0
+            rightMargin: root.isDragging ? 2 : 0
+        }
+        implicitHeight: Math.max(48, contentLayout.implicitHeight + 20)
+        radius: Appearance.rounding.normal
+        color: root.isDragging ? Appearance.colors.colLayer2Hover : Appearance.colors.colLayer2
+        border.width: root.isDragging ? 2 : 1
+        border.color: root.isDragging
+            ? Appearance.colors.colPrimary
+            : ColorUtils.transparentize(Appearance.colors.colOutlineVariant, 0.7)
+
+        Behavior on anchors.leftMargin { NumberAnimation { duration: Appearance.animation.elementMoveFast.duration } }
+        Behavior on anchors.rightMargin { NumberAnimation { duration: Appearance.animation.elementMoveFast.duration } }
+        Behavior on color { ColorAnimation { duration: Appearance.animation.elementMoveFast.duration } }
+        Behavior on border.color { ColorAnimation { duration: Appearance.animation.elementMoveFast.duration } }
+
+        // Dedicated vertical drag strip on the left with 6-dot drag indicator
+        Item {
+            id: dragStrip
+            anchors {
+                top: parent.top
+                bottom: parent.bottom
+                left: parent.left
+            }
+            width: 26
+
+            MaterialSymbol {
+                anchors.centerIn: parent
+                text: "drag_indicator"
+                iconSize: 18
+                color: root.isDragging ? Appearance.colors.colPrimary : Appearance.colors.colSubtext
+                opacity: root.isDragging ? 1.0 : (root.isHandleHovered ? 0.9 : 0.4)
+                Behavior on color { ColorAnimation { duration: Appearance.animation.elementMoveFast.duration } }
+                Behavior on opacity { NumberAnimation { duration: Appearance.animation.elementMoveFast.duration } }
+            }
+        }
+
+        // Delete "X" button top right
+        RippleButton {
+            id: deleteButton
+            anchors {
+                top: parent.top
+                right: parent.right
+                margins: 8
+            }
+            z: 10
+            implicitWidth: 28
+            implicitHeight: 28
+            buttonRadius: Appearance.rounding.full
+            colBackground: ColorUtils.transparentize(Appearance.colors.colLayer1, 0.2)
+            colBackgroundHover: Appearance.colors.colErrorContainer
+            colRipple: Appearance.colors.colError
+
+            contentItem: MaterialSymbol {
+                anchors.centerIn: parent
+                text: "close"
+                iconSize: 15
+                color: deleteButton.hovered ? Appearance.colors.colOnErrorContainer : Appearance.colors.colSubtext
+                horizontalAlignment: Text.AlignHCenter
+            }
+
+            StyledToolTip {
+                extraVisibleCondition: deleteButton.hovered
+                text: Translation.tr("Delete")
+            }
+
+            onClicked: {
+                Pinboard.deletePin(root.pinId)
+            }
+        }
+
+        ColumnLayout {
+            id: contentLayout
+            anchors {
+                top: parent.top
+                left: dragStrip.right
+                right: parent.right
+                margins: 10
+                leftMargin: 2
+            }
+            spacing: 8
+
+            // Image section (if item contains an image)
+            Rectangle {
+                id: imageContainer
+                visible: root.pinImage.length > 0
+                Layout.fillWidth: true
+                // Scale height proportionally to the image's natural aspect ratio.
+                implicitHeight: {
+                    if (!visible) return 0;
+                    const iw = displayImage.implicitWidth;
+                    const ih = displayImage.implicitHeight;
+                    if (iw > 0 && ih > 0) {
+                        const scaled = (width * ih) / iw;
+                        return Math.min(600, Math.max(90, scaled));
+                    }
+                    return 160;
+                }
+                radius: Appearance.rounding.small
+                color: Appearance.colors.colLayer1
+                clip: true
+
+                StyledImage {
+                    id: displayImage
+                    anchors.fill: parent
+                    source: root.pinImage ? ("file://" + FileUtils.trimFileProtocol(root.pinImage)) : ""
+                    fillMode: Image.PreserveAspectFit
+                    asynchronous: true
+                    cache: true
+                }
+
+                MouseArea {
+                    id: imageMouseArea
+                    anchors.fill: parent
+                    cursorShape: Qt.PointingHandCursor
+                    hoverEnabled: true
+                    onClicked: {
+                        Quickshell.execDetached(["xdg-open", FileUtils.trimFileProtocol(root.pinImage)])
+                    }
+                    StyledToolTip {
+                        extraVisibleCondition: imageMouseArea.containsMouse
+                        text: Translation.tr("Click to open image")
+                    }
+                }
+            }
+
+            // Text section (if item contains text)
+            StyledText {
+                id: noteText
+                visible: root.pinContent.length > 0
+                Layout.fillWidth: true
+                Layout.rightMargin: (root.pinImage.length > 0) ? 0 : 28
+                text: root.pinContent
+                wrapMode: Text.Wrap
+                font.pixelSize: Appearance.font.pixelSize.small
+                color: Appearance.colors.colOnLayer2
+            }
+
+            // Footer row: timestamp & actions
+            RowLayout {
+                Layout.fillWidth: true
+                spacing: 4
+
+                StyledText {
+                    text: {
+                        if (!root.pinCreatedAt) return ""
+                        const d = new Date(root.pinCreatedAt)
+                        return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) + " · " + d.toLocaleDateString()
+                    }
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: Appearance.colors.colSubtext
+                }
+
+                Item {
+                    Layout.fillWidth: true
+                }
+
+                // "Copied!" feedback text
+                StyledText {
+                    visible: root.copiedFeedback
+                    text: Translation.tr("Copied!")
+                    font.pixelSize: Appearance.font.pixelSize.smaller
+                    color: Appearance.colors.colPrimary
+                }
+
+                // Copy button
+                RippleButton {
+                    id: copyButton
+                    implicitWidth: 28
+                    implicitHeight: 28
+                    buttonRadius: Appearance.rounding.full
+                    colBackground: "transparent"
+                    colBackgroundHover: Appearance.colors.colLayer1Hover
+
+                    contentItem: MaterialSymbol {
+                        anchors.centerIn: parent
+                        text: root.copiedFeedback ? "check" : "content_copy"
+                        iconSize: 15
+                        color: root.copiedFeedback ? Appearance.colors.colPrimary : Appearance.colors.colSubtext
+                        horizontalAlignment: Text.AlignHCenter
+                    }
+
+                    StyledToolTip {
+                        extraVisibleCondition: copyButton.hovered
+                        text: Translation.tr("Copy to clipboard")
+                    }
+
+                    onClicked: {
+                        if (root.pinContent.length > 0) {
+                            Quickshell.execDetached(["bash", "-c", `printf '%s' '${StringUtils.shellSingleQuoteEscape(root.pinContent)}' | wl-copy`])
+                            root.copiedFeedback = true
+                            copiedTimer.restart()
+                        } else if (root.pinImage.length > 0) {
+                            Quickshell.execDetached(["bash", "-c", `wl-copy -t image/png < '${StringUtils.shellSingleQuoteEscape(FileUtils.trimFileProtocol(root.pinImage))}'`])
+                            root.copiedFeedback = true
+                            copiedTimer.restart()
+                        }
+                    }
+                }
+
+                // Open in default viewer button (if image exists)
+                RippleButton {
+                    id: openButton
+                    visible: root.pinImage.length > 0
+                    implicitWidth: 28
+                    implicitHeight: 28
+                    buttonRadius: Appearance.rounding.full
+                    colBackground: "transparent"
+                    colBackgroundHover: Appearance.colors.colLayer1Hover
+
+                    contentItem: MaterialSymbol {
+                        anchors.centerIn: parent
+                        text: "open_in_new"
+                        iconSize: 15
+                        color: Appearance.colors.colSubtext
+                        horizontalAlignment: Text.AlignHCenter
+                    }
+
+                    StyledToolTip {
+                        extraVisibleCondition: openButton.hovered
+                        text: Translation.tr("Open with default app")
+                    }
+
+                    onClicked: {
+                        Quickshell.execDetached(["xdg-open", FileUtils.trimFileProtocol(root.pinImage)])
+                    }
+                }
+            }
+        }
+    }
+}

--- a/services/Pinboard.qml
+++ b/services/Pinboard.qml
@@ -1,0 +1,131 @@
+pragma Singleton
+pragma ComponentBehavior: Bound
+
+import qs.modules.common
+import qs.modules.common.functions
+import Quickshell
+import Quickshell.Io
+import QtQuick
+
+/**
+ * Pinboard manager for storing text and images.
+ * Each item has "id", "content", "image", and "createdAt".
+ */
+Singleton {
+    id: root
+
+    property string filePath: Directories.pinboardPath
+    property string imagesDir: Directories.pinboardImages
+    property var list: []
+
+    function addPin(content: string, imagePath: string): string {
+        content = (content ?? "").trim();
+        imagePath = (imagePath ?? "").trim();
+
+        if (content.length === 0 && imagePath.length === 0) {
+            return "";
+        }
+
+        const id = Date.now().toString() + "-" + Math.floor(Math.random() * 10000);
+        let finalImagePath = "";
+
+        if (imagePath.length > 0) {
+            const cleanPath = FileUtils.trimFileProtocol(imagePath);
+            if (!cleanPath.startsWith(root.imagesDir)) {
+                let ext = cleanPath.split(".").pop().toLowerCase() || "png";
+                if (ext.indexOf("?") !== -1) {
+                    ext = ext.split("?")[0];
+                }
+                finalImagePath = `${root.imagesDir}/pin_${id}.${ext}`;
+                Quickshell.execDetached(["cp", cleanPath, finalImagePath]);
+            } else {
+                finalImagePath = cleanPath;
+            }
+        }
+
+        const item = {
+            "id": id,
+            "content": content,
+            "image": finalImagePath,
+            "createdAt": Date.now()
+        };
+
+        list.unshift(item);
+        root.list = list.slice(0);
+        save();
+        return item.id;
+    }
+
+    function deletePin(id: string): void {
+        const idx = list.findIndex(p => p.id === id);
+        if (idx >= 0) {
+            const item = list[idx];
+            if (item.image && item.image.startsWith(root.imagesDir)) {
+                Quickshell.execDetached(["rm", "-f", item.image]);
+            }
+            list.splice(idx, 1);
+            root.list = list.slice(0);
+            save();
+        }
+    }
+
+    function clearAll(): void {
+        Quickshell.execDetached(["bash", "-c", `rm -rf '${root.imagesDir}'/*`]);
+        list = [];
+        root.list = [];
+        save();
+    }
+
+    function movePin(from: int, to: int): void {
+        if (from === to) return;
+        if (from < 0 || from >= list.length) return;
+        if (to < 0 || to >= list.length) return;
+        const arr = root.list.slice(0);
+        const item = arr.splice(from, 1)[0];
+        arr.splice(to, 0, item);
+        list = arr;
+        root.list = arr;
+        save();
+    }
+
+    function save(): void {
+        pinboardFileView.setText(JSON.stringify(root.list, null, 2));
+    }
+
+    function refresh(): void {
+        pinboardFileView.reload();
+    }
+
+    Component.onCompleted: {
+        Quickshell.execDetached(["mkdir", "-p", `${root.imagesDir}`]);
+        refresh();
+    }
+
+    FileView {
+        id: pinboardFileView
+        path: Qt.resolvedUrl(root.filePath)
+        onLoaded: {
+            const fileContents = pinboardFileView.text();
+            try {
+                const parsed = JSON.parse(fileContents);
+                root.list = Array.isArray(parsed) ? parsed : [];
+                list = root.list;
+            } catch (e) {
+                console.log("[Pinboard] Corrupt or empty file, resetting to empty list. Error: " + e);
+                root.list = [];
+                list = [];
+                save();
+            }
+            console.log("[Pinboard] File loaded with " + root.list.length + " items");
+        }
+        onLoadFailed: (error) => {
+            if (error == FileViewError.FileNotFound) {
+                console.log("[Pinboard] File not found, creating new file.");
+                root.list = [];
+                save();
+            } else {
+                console.log("[Pinboard] Error loading file: " + error);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Adds a new **Pinboard** tab to the left sidebar for storing, organizing, and browsing pinned notes and images.

---

## Features
- **Sidebar Tab Integration**: Adds a `Pinboard` tab with `push_pin` icon and sidebar configuration toggle (`Config.options.sidebar.pinboard.enable`).
- **Bottom Compose Card**:
  - Multi-line text input with `Ctrl+Enter` to pin and `Ctrl+V` clipboard paste.
  - Image picker dialog (supports Zenity / KDialog).
  - Smart clipboard paste: auto-detects copied images or text and attaches them.
- **Responsive Image Scaling**: Pinned images dynamically scale to the full sidebar width while preserving their native aspect ratios.
- **Draggable Reordering**:
  - Dedicated 6-dot vertical drag handle (`drag_indicator`) on the left of each card.
  - Smooth card displacement animations with elevated highlight state.
  - **Edge Auto-Scrolling**: Continuously auto-scrolls the list when dragging cards near or beyond the top/bottom viewport edges.
- **Item-by-Item Browsing**:
  - Top navigation bar showing current item index (`Pin N of M`) with previous/next scroll buttons.
  - Smooth snap-to-item scrolling with mouse wheel support.
- **Card Actions**:
  - One-click copy text/image to clipboard with visual feedback.
  - Open images in default external viewer (`xdg-open`).
  - Delete `X` button on the top-right of each card.
- **Clear All**: Bottom summary bar with pinned item counter and a one-click "Clear all" button.
-**Persistence**: Backed by `services/Pinboard.qml` using `FileView` JSON storage (`~/.local/state/quickshell/user/pinboard.json`) and persistent image cache (`pinboard_images/`).

---

## Changed / Added Files
- `services/Pinboard.qml` *(new)*: Singleton service managing JSON persistence, file operations, and item reordering.
- `modules/ii/sidebarLeft/PinboardWidget.qml` *(new)*: Main UI container with compose card, navigation header, auto-scrolling ListView, and clear bar.
- `modules/ii/sidebarLeft/pinboard/PinboardItem.qml` *(new)*: Individual pinned item card with dynamic image scaling and left drag handle.
- `modules/ii/sidebarLeft/SidebarLeftContent.qml`: Integrated Pinboard tab and page into the sidebar's SwipeView.
- `modules/common/Directories.qml`: Added `pinboardPath` and `pinboardImages` directories.
- `modules/common/Config.qml`: Added `sidebar.pinboard` config options.
