### PR TITLE
Add standalone equalizer bar widget popup

### DIFF
--- a/GlobalStates.qml
+++ b/GlobalStates.qml
@@ -12,6 +12,7 @@ Singleton {
     signal requestBluetoothDialog()
     property bool barOpen: true
     property bool crosshairOpen: false
+    property bool equalizerOpen: false
     property bool sidebarLeftOpen: false
     property bool sidebarRightOpen: false
     property bool mediaControlsOpen: false

--- a/modules/common/Directories.qml
+++ b/modules/common/Directories.qml
@@ -55,6 +55,8 @@ Singleton {
     property string userPresetsPath: FileUtils.trimFileProtocol(`${Directories.shellConfig}/presets`)
     property string presetsScriptPath: FileUtils.trimFileProtocol(`${Directories.scriptPath}/presets.sh`)
     property string generatedLockMaterialThemePath: FileUtils.trimFileProtocol(`${Directories.state}/user/generated/colors-lock.json`)
+    property string eqScriptPath: FileUtils.trimFileProtocol(`${Directories.scriptPath}/eq/equalizer.sh`)
+    property string eqStateDir: FileUtils.trimFileProtocol(`${Directories.state}/user/eq`)
     // Cleanup on init
     Component.onCompleted: {
         Quickshell.execDetached(["mkdir", "-p", `${userPresetsPath}`])
@@ -66,6 +68,7 @@ Singleton {
         Quickshell.execDetached(["bash", "-c", `rm -rf '${cliphistDecode}'; mkdir -p '${cliphistDecode}'`])
         Quickshell.execDetached(["mkdir", "-p", `${aiChats}`])
         Quickshell.execDetached(["mkdir", "-p", `${userActions}`])
+        Quickshell.execDetached(["mkdir", "-p", `${eqStateDir}`])
         Quickshell.execDetached(["rm", "-rf", `${tempImages}`])
     }
 }

--- a/modules/common/widgets/PlayerControls.qml
+++ b/modules/common/widgets/PlayerControls.qml
@@ -181,6 +181,11 @@ Item {
                         visible: !GlobalStates.sidebarRightOpen
                         downAction: () => root.toggleLyrics()
                     }
+
+                    TrackChangeButton {
+                        iconName: "equalizer"
+                        downAction: () => GlobalStates.equalizerOpen = !GlobalStates.equalizerOpen
+                    }
                 }
 
                 RippleButton {

--- a/modules/common/widgets/PlayerControlsLyrics.qml
+++ b/modules/common/widgets/PlayerControlsLyrics.qml
@@ -207,6 +207,11 @@ Item {
                         iconName: "lyrics"
                         downAction: () => root.toggleLyrics()
                     }
+
+                    TrackChangeButton {
+                        iconName: "equalizer"
+                        downAction: () => GlobalStates.equalizerOpen = !GlobalStates.equalizerOpen
+                    }
                 }
 
                 RippleButton {

--- a/modules/ii/equalizer/EqualizerPopup.qml
+++ b/modules/ii/equalizer/EqualizerPopup.qml
@@ -1,0 +1,217 @@
+pragma ComponentBehavior: Bound
+import qs
+import qs.services
+import qs.modules.common
+import qs.modules.common.models
+import qs.modules.common.widgets
+import qs.modules.common.functions
+import Qt5Compat.GraphicalEffects
+import QtQuick
+import QtQuick.Effects
+import QtQuick.Layouts
+import Quickshell
+import Quickshell.Io
+import Quickshell.Wayland
+import Quickshell.Services.Mpris
+
+// Standalone popup, opened only via the "equalizer" button inside the media
+// popup's controls (PlayerControls.qml / PlayerControlsLyrics.qml) - there is
+// no separate bar icon for it. Sized on its own terms - nothing here
+// references Appearance.sizes.mediaControlsWidth.
+//
+// Visually styled like Player.qml's media card (blurred now-playing art, cava
+// wave visualizer, border) since that's the "look" being matched, even though
+// this popup isn't tied to any one player/track - it just reflects whatever
+// MprisController.activePlayer currently is, same as the bar's media widget.
+//
+// Uses the same Loader-active pattern as modules/ii/mediaControls/MediaControls.qml:
+// the PanelWindow is created/destroyed by the Loader in step with
+// GlobalStates.equalizerOpen, so the popup's entrance/exit is whatever native
+// map/unmap animation the compositor (Hyprland) already plays for every other
+// quickshell layer-shell surface - the same "pop" you see opening media -
+// rather than a hand-rolled QML slide.
+Scope {
+    id: root
+
+    readonly property real popupWidth: 760
+    readonly property real popupHeight: 640
+    readonly property real popupRounding: Appearance.rounding.screenRounding - Appearance.sizes.hyprlandGapsOut + 1
+
+    // No standalone "equalizer" bar entry anymore - it only opens via the
+    // button inside the media popup, so position it the same way the media
+    // popup itself is positioned (wherever "media" sits in the bar layout).
+    readonly property string equalizerPosition: {
+        if (Config.options.bar.layouts.leftLayout.includes("media")) return "left"
+        if (Config.options.bar.layouts.middleLayout.includes("media")) return "center"
+        if (Config.options.bar.layouts.rightLayout.includes("media")) return "right"
+        return "center"
+    }
+
+    readonly property bool barVertical: Config.options.bar.vertical
+    readonly property string barEdge: {
+        if (!barVertical) return Config.options.bar.bottom ? "bottom" : "top"
+        return Config.options.bar.bottom ? "right" : "left"
+    }
+    readonly property real gap: Config.options.bar.cornerStyle === 3 ? Appearance.sizes.hyprlandGapsOut : 0
+    readonly property bool cornerStyleReducesGap: Config.options.bar.cornerStyle === 1 || Config.options.bar.cornerStyle === 2
+    readonly property real barThickness: barVertical ? Appearance.sizes.verticalBarWidth : Appearance.sizes.barHeight
+
+    // Now-playing art, purely decorative here (same download-cache approach
+    // Player.qml uses) - if nothing is playing this just stays blank and the
+    // card falls back to a plain tinted background.
+    readonly property MprisPlayer activePlayer: MprisController.activePlayer
+    readonly property var artUrl: activePlayer?.trackArtUrl ?? ""
+    readonly property string artFilePath: `${Directories.coverArt}/${Qt.md5(root.artUrl)}`
+    property bool artDownloaded: false
+    readonly property string displayedArtFilePath: {
+        if (!root.artUrl || root.artUrl.length === 0) return ""
+        if (!root.artDownloaded) return ""
+        if (root.artUrl.startsWith("file://")) return root.artUrl
+        return Qt.resolvedUrl(root.artFilePath)
+    }
+    readonly property color artDominantColor: ColorUtils.mix(
+        (colorQuantizer?.colors[0] ?? Appearance.colors.colPrimary),
+        Appearance.colors.colPrimaryContainer,
+        0.8) || Appearance.m3colors.m3secondaryContainer
+    readonly property QtObject blendedColors: AdaptedMaterialScheme {
+        color: root.artDominantColor
+    }
+
+    onArtUrlChanged: {
+        if (!root.artUrl || root.artUrl.length === 0) {
+            root.artDownloaded = false
+            return
+        }
+        if (root.artUrl.startsWith("file://")) {
+            root.artDownloaded = true
+            return
+        }
+        root.artDownloaded = false
+        coverArtDownloader.running = true
+    }
+
+    Process {
+        id: coverArtDownloader
+        property string targetFile: root.artUrl
+        property string targetPath: root.artFilePath
+        command: ["bash", "-c", `[ -f ${targetPath} ] || curl -4 -sSL '${targetFile}' -o '${targetPath}'`]
+        onExited: root.artDownloaded = true
+    }
+
+    ColorQuantizer {
+        id: colorQuantizer
+        source: root.displayedArtFilePath
+        depth: 0
+        rescaleSize: 1
+    }
+
+    Loader {
+        id: equalizerLoader
+        active: GlobalStates.equalizerOpen
+
+        sourceComponent: PanelWindow {
+            id: panelWindow
+            visible: true
+
+            exclusionMode: ExclusionMode.Ignore
+            exclusiveZone: 0
+            implicitWidth: root.popupWidth
+            implicitHeight: root.popupHeight
+            color: "transparent"
+            WlrLayershell.namespace: "quickshell:equalizer"
+
+            anchors {
+                top: true
+                left: true
+            }
+            margins {
+                top: {
+                    if (root.barEdge === "top") return root.barThickness + (root.cornerStyleReducesGap ? -root.gap - 6 : root.gap)
+                    if (root.barEdge === "bottom") return panelWindow.screen.height - root.barThickness - (root.cornerStyleReducesGap ? -root.gap : root.gap) - root.popupHeight
+                    if (root.equalizerPosition === "left") return 0
+                    if (root.equalizerPosition === "right") return panelWindow.screen.height - root.popupHeight - root.gap
+                    return (panelWindow.screen.height - root.popupHeight) / 2
+                }
+                left: {
+                    if (root.barEdge === "left") return root.barThickness + (root.cornerStyleReducesGap ? -root.gap : root.gap)
+                    if (root.barEdge === "right") return panelWindow.screen.width - root.barThickness - (root.cornerStyleReducesGap ? -root.gap : root.gap) - root.popupWidth
+                    if (root.equalizerPosition === "left") return 0
+                    if (root.equalizerPosition === "right") return panelWindow.screen.width - root.popupWidth - root.gap
+                    return (panelWindow.screen.width - root.popupWidth) / 2
+                }
+            }
+
+            mask: Region {
+                item: cardBackground
+            }
+
+            Component.onCompleted: GlobalFocusGrab.addDismissable(panelWindow)
+            Component.onDestruction: GlobalFocusGrab.removeDismissable(panelWindow)
+            Connections {
+                target: GlobalFocusGrab
+                function onDismissed() { GlobalStates.equalizerOpen = false }
+            }
+
+            StyledRectangularShadow {
+                target: cardBackground
+            }
+
+            Rectangle {
+                id: cardBackground
+                anchors.fill: parent
+                anchors.margins: Appearance.sizes.elevationMargin
+                radius: root.popupRounding
+                color: ColorUtils.applyAlpha(root.blendedColors.colLayer0, 1)
+                border.width: 1
+                border.color: ColorUtils.transparentize(root.blendedColors.colOnLayer0, 0.85)
+
+                layer.enabled: true
+                layer.effect: OpacityMask {
+                    maskSource: Rectangle {
+                        width: cardBackground.width
+                        height: cardBackground.height
+                        radius: cardBackground.radius
+                    }
+                }
+
+                Image {
+                    id: blurredArt
+                    anchors.fill: parent
+                    source: root.displayedArtFilePath
+                    sourceSize.width: cardBackground.width
+                    sourceSize.height: cardBackground.height
+                    fillMode: Image.PreserveAspectCrop
+                    cache: false
+                    antialiasing: true
+                    asynchronous: true
+                    visible: root.displayedArtFilePath.length > 0
+
+                    layer.enabled: true
+                    layer.effect: StyledBlurEffect {
+                        source: blurredArt
+                    }
+
+                    Rectangle {
+                        anchors.fill: parent
+                        color: ColorUtils.transparentize(root.blendedColors.colLayer0, 0.25)
+                    }
+                }
+
+                WaveVisualizer {
+                    anchors.fill: parent
+                    live: root.activePlayer?.isPlaying ?? false
+                    points: GlobalStates.visualizerPoints
+                    maxVisualizerValue: 1000
+                    smoothing: 2
+                    color: root.blendedColors.colPrimary
+                }
+
+                EqualizerView {
+                    anchors.fill: parent
+                    blendedColors: root.blendedColors
+                    onCloseRequested: GlobalStates.equalizerOpen = false
+                }
+            }
+        }
+    }
+}

--- a/modules/ii/equalizer/EqualizerView.qml
+++ b/modules/ii/equalizer/EqualizerView.qml
@@ -1,0 +1,342 @@
+pragma ComponentBehavior: Bound
+import qs.modules.common
+import qs.modules.common.widgets
+import qs.services
+import qs.modules.common.functions
+import QtQuick
+import QtQuick.Layouts
+import Quickshell
+import Quickshell.Io
+
+// A 10-band live equalizer, ported from ilyaMiro's Serpantinum MusicPopup
+// equalizer. Originally embedded in Player.qml's controls/lyrics view-swap,
+// now a standalone bar widget + popup (see modules/ii/bar/Equalizer.qml and
+// EqualizerPopup.qml) so its width isn't tied to the media popup at all.
+// Talks to EasyEffects through scripts/eq/equalizer.sh.
+Item {
+    id: root
+
+    // Passed in by EqualizerPopup.qml - a scheme tinted off the currently
+    // playing track's art (or plain Appearance.colors as a standalone fallback)
+    // so this matches the media popup's look-and-feel.
+    property QtObject blendedColors: Appearance.colors
+    signal closeRequested()
+
+    // b1..b10 gains in dB, mirrors eq_state.json written by equalizer.sh
+    property var bands: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    property string presetName: "Flat"
+    property bool pending: false
+    readonly property var bandLabels: ["32", "63", "125", "250", "500", "1k", "2k", "4k", "8k", "16k"]
+    readonly property real bandRange: 12 // -12dB .. +12dB, matches equalizer.sh clamp expectations
+
+    // Mirrors equalizer.sh's save_preset() calls exactly, so tapping a
+    // preset chip moves the sliders immediately instead of waiting on a
+    // shell round-trip to read the state file back.
+    readonly property var presetValues: ({
+        "Flat":    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        "Bass":    [5, 7, 5, 2, 1, 0, 0, 0, 1, 2],
+        "Treble":  [-2, -1, 0, 1, 2, 3, 4, 5, 6, 6],
+        "Vocal":   [-2, -1, 1, 3, 5, 5, 4, 2, 1, 0],
+        "Pop":     [2, 4, 2, 0, 1, 2, 4, 2, 1, 2],
+        "Rock":    [5, 4, 2, -1, -2, -1, 2, 4, 5, 6],
+        "Jazz":    [3, 3, 1, 1, 1, 1, 2, 1, 2, 3],
+        "Classic": [0, 1, 2, 2, 2, 2, 1, 2, 3, 4]
+    })
+    readonly property var presetIcons: ({
+        "Flat": "horizontal_rule", "Bass": "graphic_eq", "Treble": "trending_up",
+        "Vocal": "mic", "Pop": "star", "Rock": "bolt", "Jazz": "piano", "Classic": "music_note"
+    })
+
+    function refresh() {
+        eqGetProc.running = false
+        eqGetProc.running = true
+    }
+
+    function setBand(index, value) {
+        root.bands[index] = value
+        root.bandsChanged()
+        root.presetName = "Custom"
+        root.pending = true
+        Quickshell.execDetached(["bash", Directories.eqScriptPath, Directories.eqStateDir, "set_band", String(index + 1), String(Math.round(value))])
+    }
+
+    function applyPending() {
+        Quickshell.execDetached(["bash", Directories.eqScriptPath, Directories.eqStateDir, "apply"])
+        root.pending = false
+    }
+
+    function applyPreset(name) {
+        // Update sliders instantly from the known preset values...
+        const vals = root.presetValues[name]
+        if (vals) root.bands = vals.slice()
+        root.presetName = name
+        root.pending = false
+        // ...while the backend writes + loads the matching EasyEffects preset.
+        Quickshell.execDetached(["bash", Directories.eqScriptPath, Directories.eqStateDir, "preset", name])
+    }
+
+    Component.onCompleted: root.refresh()
+
+    Process {
+        id: eqGetProc
+        command: ["bash", Directories.eqScriptPath, Directories.eqStateDir, "get"]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                try {
+                    const data = JSON.parse(text)
+                    root.bands = [
+                        Number(data.b1), Number(data.b2), Number(data.b3), Number(data.b4), Number(data.b5),
+                        Number(data.b6), Number(data.b7), Number(data.b8), Number(data.b9), Number(data.b10)
+                    ]
+                    root.presetName = data.preset ?? "Custom"
+                    root.pending = !!data.pending
+                } catch (e) {
+                    // Leave previous values if the state file isn't ready yet
+                }
+            }
+        }
+    }
+
+    component SectionCard: Rectangle {
+        radius: Appearance.rounding.large
+        color: ColorUtils.transparentize(root.blendedColors.colLayer1, 0.35)
+    }
+
+    component SectionHeader: StyledText {
+        font.pixelSize: Appearance.font.pixelSize.small
+        font.bold: true
+        color: root.blendedColors.colSubtext
+    }
+
+    ColumnLayout {
+        anchors.fill: parent
+        anchors.margins: 20
+        spacing: 16
+
+        // Header: icon, title/preset, close
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 12
+
+            Rectangle {
+                implicitWidth: 46
+                implicitHeight: 46
+                radius: Appearance.rounding.normal
+                color: ColorUtils.transparentize(root.blendedColors.colPrimary, 0.85)
+
+                MaterialSymbol {
+                    anchors.centerIn: parent
+                    iconSize: Appearance.font.pixelSize.huge
+                    fill: 1
+                    text: "equalizer"
+                    color: root.blendedColors.colPrimary
+                }
+            }
+
+            ColumnLayout {
+                Layout.fillWidth: true
+                spacing: 0
+                StyledText {
+                    Layout.fillWidth: true
+                    font.pixelSize: Appearance.font.pixelSize.title
+                    font.bold: true
+                    color: root.blendedColors.colOnLayer0
+                    elide: Text.ElideRight
+                    text: Translation.tr("Equalizer")
+                }
+                StyledText {
+                    Layout.fillWidth: true
+                    font.pixelSize: Appearance.font.pixelSize.small
+                    color: root.blendedColors.colSubtext
+                    elide: Text.ElideRight
+                    text: `${Translation.tr("Preset")}: ${root.presetName}`
+                }
+            }
+
+            RippleButton {
+                implicitWidth: 36
+                implicitHeight: 36
+                buttonRadius: Appearance.rounding.full
+                colBackground: ColorUtils.transparentize(root.blendedColors.colSecondaryContainer, 1)
+                colBackgroundHover: root.blendedColors.colSecondaryContainerHover
+                colRipple: root.blendedColors.colSecondaryContainerActive
+                downAction: () => root.closeRequested()
+                contentItem: MaterialSymbol {
+                    iconSize: Appearance.font.pixelSize.huge
+                    fill: 1
+                    horizontalAlignment: Text.AlignHCenter
+                    color: root.blendedColors.colOnSecondaryContainer
+                    text: "close"
+                }
+            }
+        }
+
+        // Bands card
+        SectionCard {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            Layout.minimumHeight: 320
+
+            ColumnLayout {
+                anchors.fill: parent
+                anchors.margins: 16
+                spacing: 10
+
+                SectionHeader {
+                    text: Translation.tr("Bands")
+                }
+
+                RowLayout {
+                    id: bandRow
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    spacing: 8
+
+                    Repeater {
+                        model: root.bandLabels.length
+
+                        delegate: ColumnLayout {
+                            required property int index
+                            Layout.fillWidth: true
+                            Layout.preferredWidth: 0
+                            Layout.fillHeight: true
+                            spacing: 6
+
+                            StyledText {
+                                Layout.alignment: Qt.AlignHCenter
+                                font.pixelSize: Appearance.font.pixelSize.smallest
+                                font.features: { "tnum": 1 }
+                                color: root.blendedColors.colSubtext
+                                text: `${Math.round(root.bands[index] ?? 0) > 0 ? "+" : ""}${Math.round(root.bands[index] ?? 0)}`
+                            }
+
+                            Item {
+                                Layout.fillWidth: true
+                                Layout.fillHeight: true
+
+                                // 0dB reference line
+                                Rectangle {
+                                    anchors.horizontalCenter: parent.horizontalCenter
+                                    anchors.verticalCenter: parent.verticalCenter
+                                    width: parent.width * 0.5
+                                    height: 1
+                                    color: ColorUtils.transparentize(root.blendedColors.colSubtext, 0.7)
+                                }
+
+                                StyledSlider {
+                                    id: bandSlider
+                                    anchors.centerIn: parent
+                                    width: parent.height - 4
+                                    height: parent.width
+                                    rotation: -90
+                                    configuration: StyledSlider.Configuration.M
+                                    from: -root.bandRange
+                                    to: root.bandRange
+                                    value: root.bands[index] ?? 0
+                                    highlightColor: root.blendedColors.colPrimary
+                                    trackColor: root.blendedColors.colSecondaryContainer
+                                    handleColor: root.blendedColors.colPrimary
+                                    usePercentTooltip: false
+                                    tooltipContent: `${Math.round(value) > 0 ? "+" : ""}${Math.round(value)} dB`
+                                    onMoved: root.setBand(index, value)
+
+                                    Behavior on value {
+                                        enabled: !bandSlider.pressed
+                                        NumberAnimation { duration: 260; easing.type: Easing.OutCubic }
+                                    }
+                                }
+                            }
+
+                            StyledText {
+                                Layout.alignment: Qt.AlignHCenter
+                                font.pixelSize: Appearance.font.pixelSize.smallest
+                                color: root.blendedColors.colSubtext
+                                text: root.bandLabels[index]
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Presets card
+        SectionCard {
+            Layout.fillWidth: true
+            implicitHeight: presetsColumn.implicitHeight + 32
+
+            ColumnLayout {
+                id: presetsColumn
+                anchors.fill: parent
+                anchors.margins: 16
+                spacing: 10
+
+                SectionHeader {
+                    text: Translation.tr("Presets")
+                }
+
+                GridLayout {
+                    Layout.fillWidth: true
+                    columns: 4
+                    columnSpacing: 10
+                    rowSpacing: 10
+
+                    Repeater {
+                        model: Object.keys(root.presetValues)
+
+                        delegate: GroupButton {
+                            id: presetBtn
+                            required property string modelData
+                            Layout.fillWidth: true
+                            Layout.fillHeight: true
+                            buttonText: Translation.tr(modelData)
+                            toggled: root.presetName === modelData
+                            downAction: () => root.applyPreset(modelData)
+                            // contentItem is stretched to the button's full (grid-cell)
+                            // width by QQC2, so the icon+label pair is centered inside
+                            // an Item rather than left-packed by a bare RowLayout.
+                            contentItem: Item {
+                                implicitWidth: presetBtnContent.implicitWidth
+                                implicitHeight: presetBtnContent.implicitHeight
+                                RowLayout {
+                                    id: presetBtnContent
+                                    anchors.centerIn: parent
+                                    spacing: 6
+                                    MaterialSymbol {
+                                        iconSize: Appearance.font.pixelSize.large
+                                        fill: 0
+                                        text: root.presetIcons[presetBtn.modelData] ?? "tune"
+                                        color: presetBtn.toggled ? root.blendedColors.colOnPrimary : root.blendedColors.colOnLayer1
+                                    }
+                                    StyledText {
+                                        text: presetBtn.buttonText
+                                        color: presetBtn.toggled ? root.blendedColors.colOnPrimary : root.blendedColors.colOnLayer1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Bottom actions
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: 10
+
+            DialogButton {
+                buttonText: Translation.tr("Reset")
+                downAction: () => root.applyPreset("Flat")
+            }
+
+            Item { Layout.fillWidth: true }
+
+            DialogButton {
+                buttonText: root.pending ? Translation.tr("Apply") : Translation.tr("Applied")
+                enabled: root.pending
+                colEnabled: root.blendedColors.colPrimary
+                downAction: () => root.applyPending()
+            }
+        }
+    }
+}

--- a/modules/ii/mediaControls/MediaControls.qml
+++ b/modules/ii/mediaControls/MediaControls.qml
@@ -82,6 +82,7 @@ Scope {
         running: (GlobalStates.mediaControlsOpen ||
             GlobalStates.sidebarRightOpen ||
             (GlobalStates.sidebarLeftOpen && !GlobalStates.mediaLyricsVisible) ||
+            GlobalStates.equalizerOpen ||
             Config.options.bar.layouts.leftLayout.includes("visualizer") ||
             Config.options.bar.layouts.middleLayout.includes("visualizer") ||
             Config.options.bar.layouts.rightLayout.includes("visualizer") ||

--- a/panelFamilies/IllogicalImpulseFamily.qml
+++ b/panelFamilies/IllogicalImpulseFamily.qml
@@ -5,6 +5,7 @@ import qs.modules.common
 import qs.modules.ii.background
 import qs.modules.ii.bar
 import qs.modules.ii.dock
+import qs.modules.ii.equalizer
 import qs.modules.ii.lock
 import qs.modules.ii.mediaControls
 import qs.modules.ii.notificationPopup
@@ -30,6 +31,7 @@ Scope {
     PanelLoader { extraCondition: !Config.options.bar.vertical; component: Bar {} }
     PanelLoader { component: Background {} }
     PanelLoader { extraCondition: Config.options.dock.enable; component: Dock {} }
+    PanelLoader { component: EqualizerPopup {} }
     PanelLoader { component: Lock {} }
     PanelLoader { component: MediaControls {} }
     PanelLoader { component: NotificationPopup {} }

--- a/scripts/eq/equalizer.sh
+++ b/scripts/eq/equalizer.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# Live 10-band equalizer backend for illogical-impulse / end-4's pC fork,
+# ported from ilyaMiro's Serpantinum shell.
+#
+# It writes a 32-band EasyEffects "Equalizer" preset (only 10 of the bands
+# are user-editable, matching Serpantinum's slider layout) and loads it live
+# through `easyeffects -l`.
+#
+# Usage:
+#   equalizer.sh <state_dir> get
+#   equalizer.sh <state_dir> set_band <1-10> <gainDb>
+#   equalizer.sh <state_dir> apply
+#   equalizer.sh <state_dir> preset <Flat|Bass|Treble|Vocal|Pop|Rock|Jazz|Classic>
+#
+# <state_dir> is expected to be Directories.eqStateDir from the QML side
+# (e.g. ~/.local/state/quickshell/user/eq), passed in so this script never
+# has to guess XDG paths itself.
+
+set -u
+
+STATE_DIR="$1"; shift
+cmd="${1:-}"; arg1="${2:-}"; arg2="${3:-}"
+
+mkdir -p "$STATE_DIR"
+STATE_FILE="$STATE_DIR/eq_state.json"
+PRESET_DIR="$HOME/.config/easyeffects/output"
+PRESET_NAME="live_eq"
+PRESET_FILE="$PRESET_DIR/${PRESET_NAME}.json"
+
+mkdir -p "$PRESET_DIR"
+
+if [ ! -f "$STATE_FILE" ]; then
+    echo '{"b1": 0, "b2": 0, "b3": 0, "b4": 0, "b5": 0, "b6": 0, "b7": 0, "b8": 0, "b9": 0, "b10": 0, "preset": "Flat", "pending": false}' > "$STATE_FILE"
+fi
+
+apply_eq() {
+    vals=$(cat "$STATE_FILE")
+    python3 -c "
+import sys, json
+try:
+    data = json.loads(sys.argv[1])
+    # 10 user-facing sliders -> spread across a 32-band IIR equalizer,
+    # same mapping Serpantinum uses so presets/behaviour stay identical.
+    slider_map = { 0:0, 1:3, 2:6, 3:9, 4:12, 5:15, 6:18, 7:21, 8:24, 9:27 }
+    freqs = [32, 40, 50, 63, 80, 100, 125, 160, 200, 250, 315, 400, 500, 630, 800, 1000, 1250, 1600, 2000, 2500, 3150, 4000, 5000, 6300, 8000, 10000, 12500, 16000, 20000, 22000, 24000, 24000]
+    gains = [float(data['b1']), float(data['b2']), float(data['b3']), float(data['b4']), float(data['b5']), float(data['b6']), float(data['b7']), float(data['b8']), float(data['b9']), float(data['b10'])]
+    bands = {}
+    for i in range(32):
+        freq = freqs[i] if i < len(freqs) else 20000.0
+        gain = 0.0
+        for s_idx, b_idx in slider_map.items():
+            if i == b_idx:
+                gain = gains[s_idx]
+                break
+        bands[f'band{i}'] = { 'frequency': freq, 'gain': gain, 'mode': 'Bell', 'mute': False, 'q': 1.0, 'solo': False, 'width': 1.0, 'slope': 'x1' }
+    preset = { 'output': { 'blocklist': [], 'plugins_order': [ 'equalizer' ], 'equalizer': { 'bypass': False, 'input-gain': 0.0, 'output-gain': 0.0, 'left': bands, 'right': bands, 'mode': 'IIR', 'num-bands': 32, 'split-channels': False } } }
+    print(json.dumps(preset, indent=4))
+except Exception:
+    sys.exit(1)
+" "$vals" > "$PRESET_FILE"
+
+    easyeffects -l "$PRESET_NAME" >/dev/null 2>&1 &
+}
+
+save_preset() {
+    jq -n -c --arg b1 "$1" --arg b2 "$2" --arg b3 "$3" --arg b4 "$4" --arg b5 "$5" \
+          --arg b6 "$6" --arg b7 "$7" --arg b8 "$8" --arg b9 "$9" --arg b10 "${10}" --arg p "${11}" \
+       '{"b1": $b1, "b2": $b2, "b3": $b3, "b4": $b4, "b5": $b5, "b6": $b6, "b7": $b7, "b8": $b8, "b9": $b9, "b10": $b10, "preset": $p, "pending": false}' > "$STATE_FILE"
+}
+
+case "$cmd" in
+    "get") cat "$STATE_FILE" ;;
+    "set_band")
+        tmp=$(cat "$STATE_FILE")
+        updated=$(echo "$tmp" | jq -c --arg val "$arg2" ".b$arg1 = \$val | .preset = \"Custom\" | .pending = true")
+        echo "$updated" > "$STATE_FILE"
+        ;;
+    "apply")
+        tmp=$(cat "$STATE_FILE")
+        updated=$(echo "$tmp" | jq -c ".pending = false")
+        echo "$updated" > "$STATE_FILE"
+        apply_eq
+        ;;
+    "preset")
+        case "$arg1" in
+            "Flat")    save_preset 0 0 0 0 0 0 0 0 0 0 "Flat" ;;
+            "Bass")    save_preset 5 7 5 2 1 0 0 0 1 2 "Bass" ;;
+            "Treble")  save_preset -2 -1 0 1 2 3 4 5 6 6 "Treble" ;;
+            "Vocal")   save_preset -2 -1 1 3 5 5 4 2 1 0 "Vocal" ;;
+            "Pop")     save_preset 2 4 2 0 1 2 4 2 1 2 "Pop" ;;
+            "Rock")    save_preset 5 4 2 -1 -2 -1 2 4 5 6 "Rock" ;;
+            "Jazz")    save_preset 3 3 1 1 1 1 2 1 2 3 "Jazz" ;;
+            "Classic") save_preset 0 1 2 2 2 2 1 2 3 4 "Classic" ;;
+        esac
+        apply_eq
+        ;;
+    *)
+        echo "Usage: equalizer.sh <state_dir> <get|set_band|apply|preset> [args...]" >&2
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
Ports a live 10-band EasyEffects equalizer as its own popup, opened from a button in the media controls (PlayerControls/PlayerControlsLyrics), following the same PanelLoader/Scope pattern already used for the other popups (Bluetooth, media controls, sidebars, etc).

- modules/ii/equalizer/EqualizerView.qml: bands + presets UI
- modules/ii/equalizer/EqualizerPopup.qml: standalone popup window, positioned the same way MediaControls.qml positions itself, opened/closed via GlobalStates.equalizerOpen using the same Loader-based show/hide pattern as MediaControls.qml (so entrance/exit inherits the compositor's native layer-surface animation instead of a custom one)
- scripts/eq/equalizer.sh: backend - reads/writes 10 band gains + preset to a state file and applies them via easyeffects
- GlobalStates.qml: + equalizerOpen
- modules/common/Directories.qml: + eqScriptPath, eqStateDir
- modules/common/widgets/PlayerControls.qml, modules/common/widgets/PlayerControlsLyrics.qml: + equalizer button
- modules/ii/mediaControls/MediaControls.qml: cava now also runs while the equalizer popup is open (so it has visualizer data to draw)
- panelFamilies/IllogicalImpulseFamily.qml: register EqualizerPopup

Runtime deps: easyeffects, jq, python3. EasyEffects needs to be running with a live_eq preset it can create/load.