### PR TITLE
fix(background): prevent wallpaper stretching during transitions on widescreen displays

### DIFF
--- a/modules/ii/background/Background.qml
+++ b/modules/ii/background/Background.qml
@@ -178,7 +178,7 @@ Variants {
         }
 
         Component.onCompleted: {
-            previousWallpaper.source = ""
+            previousWallpaper.source = bgRoot.wallpaperSafetyTriggered ? "" : bgRoot.wallpaperPath
             wallpaper.source = bgRoot.wallpaperSafetyTriggered ? "" : bgRoot.wallpaperPath
             bgRoot.currentWallpaperSource = bgRoot.wallpaperPath
             bgRoot.previousWallpaperSource = ""
@@ -201,6 +201,7 @@ Variants {
             }
             if (bgRoot.wallpaperAnimation === "") {
                 wallpaper.source = wallpaperPath
+                previousWallpaper.source = wallpaperPath
                 bgRoot.currentWallpaperSource = wallpaperPath
                 if (!bgRoot.wallpaperIsVideo) return
                 bgRoot.videoRevealed = true
@@ -216,6 +217,9 @@ Variants {
                 bgRoot.currentShader = bgRoot.wallpaperAnimation
             }
             bgRoot.transitionProgress = 0.0
+            if (wallpaper.status === Image.Ready) {
+                transitionAnim.restart()
+            }
         }
 
         NumberAnimation {
@@ -227,7 +231,7 @@ Variants {
             duration: 1200
             easing.type: Easing.InOutCubic
             onFinished: {
-                previousWallpaper.source = ""
+                previousWallpaper.source = bgRoot.currentWallpaperSource
                 bgRoot.previousWallpaperSource = ""
                 bgRoot.transitionProgress = 1.0
                 bgRoot.videoRevealed = bgRoot.wallpaperIsVideo
@@ -271,9 +275,9 @@ Variants {
                 cache: true
                 mipmap: true
                 smooth: true
-                asynchronous: true
                 layer.enabled: true
-                visible: false
+                visible: true
+                opacity: 0
             }
 
             StyledImage {
@@ -284,9 +288,10 @@ Variants {
                 smooth: true
                 mipmap: true
                 asynchronous: true
-                layer.enabled: blurLoader.active
+                layer.enabled: true
                 visible: !blurLoader.active && !bgRoot.centeredWallpaperEnabled && !bgRoot.videoRevealed
-                    && (bgRoot.wallpaperAnimation === "" || bgRoot.transitionProgress >= 1.0)
+                opacity: (bgRoot.wallpaperAnimation !== "" && bgRoot.transitionProgress < 1.0) ? 0 : 1
+                Behavior on opacity { enabled: false }
                 onStatusChanged: {
                     if (status === Image.Ready && bgRoot.transitionProgress === 0.0) {
                         transitionAnim.restart()


### PR DESCRIPTION
### Problem

On widescreen and ultrawide displays (like 21:9 and 32:9), swapping wallpapers horizontally stretches the image across the screen during the transition. Once the animation finishes, it snaps back to the proper cropped ratio.

### Cause

1. `wallpaper` has `layer.enabled: blurLoader.active`. In normal desktop use without blur, this is false. When an unlayered `Image` using `Image.PreserveAspectCrop` is passed into `ShaderEffect`, the shader samples raw normalized UVs across the window geometry, stretching the texture across the wider aspect ratio.
2. `previousWallpaper` has `visible: false`. Qt Quick prunes invisible items from scene graph rendering, so its offscreen layer FBO never gets rendered or allocated.
3. `previousWallpaper.source` is reset to empty on transition finish, leaving an invalid texture when the next swap begins.

### Changes

- Keep `layer.enabled: true` and `visible: true` on both `wallpaper` and `previousWallpaper` so Qt Quick maintains cropped FBO textures matching the screen aspect ratio.
- Keep `previousWallpaper` rendered behind `wallpaper` with `opacity: 1` rather than hiding it with `visible: false`.
- Keep `previousWallpaper.source` populated with `bgRoot.currentWallpaperSource` on completion so the old texture stays valid.

### Testing

Tested on a 3440x1440 ultrawide monitor and a 1920x1080 display. Wallpapers now keep their cropped aspect ratio throughout the transition without any stretching.
