### PR TITLE
perf(background): fix micro-stutter at start of wallpaper transition

### DIFF
--- a/modules/ii/background/Background.qml
+++ b/modules/ii/background/Background.qml
@@ -154,6 +154,7 @@ Variants {
         }
 
         property real transitionProgress: 1.0
+        property bool transitionPending: false
 
         screen: modelData
         exclusionMode: ExclusionMode.Ignore
@@ -194,12 +195,14 @@ Variants {
         onWallpaperPathChanged: {
             bgRoot.videoRevealed = false
             if (wallpaperSafetyTriggered) {
+                bgRoot.transitionPending = false
                 previousWallpaper.source = ""
                 wallpaper.source = ""
                 bgRoot.transitionProgress = 1.0
                 return
             }
             if (bgRoot.wallpaperAnimation === "") {
+                bgRoot.transitionPending = false
                 wallpaper.source = wallpaperPath
                 previousWallpaper.source = wallpaperPath
                 bgRoot.currentWallpaperSource = wallpaperPath
@@ -209,15 +212,17 @@ Variants {
             }
 
             previousWallpaper.source = bgRoot.currentWallpaperSource
-            wallpaper.source = wallpaperPath
             bgRoot.currentWallpaperSource = wallpaperPath
             if (bgRoot.wallpaperAnimation === "random") {
                 bgRoot.currentShader = bgRoot.shaderList[Math.floor(Math.random() * bgRoot.shaderList.length)]
             } else {
                 bgRoot.currentShader = bgRoot.wallpaperAnimation
             }
-            bgRoot.transitionProgress = 0.0
+            bgRoot.transitionPending = true
+            wallpaper.source = wallpaperPath
             if (wallpaper.status === Image.Ready) {
+                bgRoot.transitionPending = false
+                bgRoot.transitionProgress = 0.0
                 transitionAnim.restart()
             }
         }
@@ -228,8 +233,8 @@ Variants {
             property: "transitionProgress"
             from: 0.0
             to: 1.0
-            duration: 1200
-            easing.type: Easing.InOutCubic
+            duration: 1000
+            easing.type: Easing.InOutQuad
             onFinished: {
                 previousWallpaper.source = bgRoot.currentWallpaperSource
                 bgRoot.previousWallpaperSource = ""
@@ -277,7 +282,7 @@ Variants {
                 smooth: true
                 layer.enabled: true
                 visible: true
-                opacity: 0
+                opacity: 1
             }
 
             StyledImage {
@@ -293,7 +298,9 @@ Variants {
                 opacity: (bgRoot.wallpaperAnimation !== "" && bgRoot.transitionProgress < 1.0) ? 0 : 1
                 Behavior on opacity { enabled: false }
                 onStatusChanged: {
-                    if (status === Image.Ready && bgRoot.transitionProgress === 0.0) {
+                    if (status === Image.Ready && bgRoot.transitionPending) {
+                        bgRoot.transitionPending = false
+                        bgRoot.transitionProgress = 0.0
                         transitionAnim.restart()
                     }
                 }


### PR DESCRIPTION
### Problem

Changing wallpapers causes a noticeable 100-250ms freeze at the start of the transition before the animation starts moving.

### Cause

1. `onWallpaperPathChanged` sets `transitionProgress = 0.0` immediately, which makes `transitionEffect` visible right away. Because `wallpaper` loads asynchronously (`asynchronous: true`), `transitionAnim` has to wait for `wallpaper.status === Image.Ready`. This leaves the shader frozen on screen at progress 0 while the image decodes.
2. `Easing.InOutCubic` over 1200ms has a flat curve at the start, making the initial movement feel sluggish.

### Changes

- Added a `transitionPending` flag. `transitionProgress` stays at 1.0 while the new wallpaper decodes in the background, keeping the current wallpaper visible on screen without showing a paused shader.
- When `wallpaper.status === Image.Ready`, `transitionProgress` is set to 0.0 and `transitionAnim.restart()` fires at the same time.
- Switched transition easing to `Easing.InOutQuad` with a 1000ms duration for a smoother start.

Builds on #95.

### Testing

Tested on a 165Hz display switching between large wallpapers. The transition starts immediately once the image is decoded with no pause on frame 0.
