### PR TITLE
feat(wallpaperSelector): add manual reordering, sort options, and fix drag-scrolling 

### DIFF
--- a/modules/common/Config.qml
+++ b/modules/common/Config.qml
@@ -812,6 +812,7 @@ Singleton {
                 property int columns: 4
                 property bool closeAfterSelection: true
                 property int changeInterval: 0 
+                property string sortMode: "custom"
             }
 
             property JsonObject windows: JsonObject {

--- a/modules/ii/wallpaperSelector/LocalWallpaperGrid.qml
+++ b/modules/ii/wallpaperSelector/LocalWallpaperGrid.qml
@@ -24,6 +24,90 @@ Item {
     property int columns: Config.options.wallpaperSelector.columns || 4
     property real previewCellAspectRatio: 4 / 3
 
+    // Drag-and-drop state
+    property bool isDragging: false
+    property int dragFromIndex: -1
+    property int dropTargetIndex: -1
+    property real dragX: 0
+    property real dragY: 0
+    property var draggedItemData: null
+
+    function startDrag(fromIdx, data, pos) {
+        dragFromIndex = fromIdx;
+        dropTargetIndex = fromIdx;
+        draggedItemData = data;
+        dragX = pos.x;
+        dragY = pos.y;
+        isDragging = true;
+    }
+
+    function updateDrag(pos) {
+        dragX = pos.x;
+        dragY = pos.y;
+
+        const gridPos = root.mapToItem(grid, pos.x, pos.y);
+        const col = Math.max(0, Math.min(root.columns - 1, Math.floor(gridPos.x / grid.cellWidth)));
+        const row = Math.floor((gridPos.y + grid.contentY) / grid.cellHeight);
+        const target = Math.max(0, Math.min(grid.model.count - 1, row * root.columns + col));
+        dropTargetIndex = target;
+
+        if (gridPos.y < 50) {
+            autoScrollUpTimer.running = true;
+            autoScrollDownTimer.running = false;
+        } else if (gridPos.y > grid.height - 50) {
+            autoScrollDownTimer.running = true;
+            autoScrollUpTimer.running = false;
+        } else {
+            autoScrollUpTimer.running = false;
+            autoScrollDownTimer.running = false;
+        }
+    }
+
+    function endDrag() {
+        autoScrollUpTimer.running = false;
+        autoScrollDownTimer.running = false;
+        if (isDragging && dragFromIndex >= 0 && dropTargetIndex >= 0 && dragFromIndex !== dropTargetIndex) {
+            Wallpapers.moveWallpaper(dragFromIndex, dropTargetIndex);
+            grid.currentIndex = dropTargetIndex;
+        }
+        isDragging = false;
+        dragFromIndex = -1;
+        dropTargetIndex = -1;
+        draggedItemData = null;
+    }
+
+    function cancelDrag() {
+        autoScrollUpTimer.running = false;
+        autoScrollDownTimer.running = false;
+        isDragging = false;
+        dragFromIndex = -1;
+        dropTargetIndex = -1;
+        draggedItemData = null;
+    }
+
+    Timer {
+        id: autoScrollUpTimer
+        interval: 16
+        repeat: true
+        running: false
+        onTriggered: {
+            grid.contentY = Math.max(0, grid.contentY - 14);
+            root.updateDrag(Qt.point(root.dragX, root.dragY));
+        }
+    }
+
+    Timer {
+        id: autoScrollDownTimer
+        interval: 16
+        repeat: true
+        running: false
+        onTriggered: {
+            const maxContentY = Math.max(0, grid.contentHeight - grid.height);
+            grid.contentY = Math.min(maxContentY, grid.contentY + 14);
+            root.updateDrag(Qt.point(root.dragX, root.dragY));
+        }
+    }
+
     Process {
         id: deleteProc
         property string filePath: ""
@@ -37,58 +121,190 @@ Item {
         }
     }
 
+    // ─── Dismiss overlay for context menu ───
+    MouseArea {
+        anchors.fill: parent
+        visible: contextMenu.visible
+        z: 105
+        acceptedButtons: Qt.LeftButton | Qt.RightButton
+        onClicked: contextMenu.visible = false
+    }
+
     // ─── Context menu ───
     Item {
         id: contextMenu
         visible: false
-        z: 3
+        z: 110
 
         property string targetPath: ""
+        property int targetIndex: -1
         property real targetX: 0
         property real targetY: 0
         property real targetWidth: grid.cellWidth
         property real targetHeight: grid.cellHeight
 
-        x: targetX
-        y: targetY
-        width: targetWidth
-        height: targetHeight
+        x: Math.max(8, Math.min(root.width - width - 8, targetX))
+        y: Math.max(8, Math.min(root.height - height - 8, targetY))
+        width: Math.max(grid.cellWidth, 230)
+        height: Math.max(grid.cellHeight, 90)
 
         Rectangle {
             anchors.fill: parent
-            anchors.margins: 8
-            color: Qt.rgba(0, 0, 0, 0.45)
+            anchors.margins: 4
+            color: Appearance.colors.colLayer1
             radius: Appearance.rounding.normal
-        }
-        Row {
-            anchors.centerIn: parent
-            spacing: 12
-            RippleButton {
-                implicitWidth: 36; implicitHeight: 36
-                buttonRadius: height / 2
-                colBackground: Appearance.colors.colPrimaryContainer
-                onClicked: contextMenu.visible = false
-                contentItem: MaterialSymbol {
-                    anchors.centerIn: parent
-                    text: "close"
-                    iconSize: Appearance.font.pixelSize.larger
-                    color: Appearance.colors.colPrimary
+            border.width: 1
+            border.color: Appearance.colors.colLayer0Border
+
+            StyledRectangularShadow {
+                target: parent
+            }
+
+            ColumnLayout {
+                anchors.centerIn: parent
+                spacing: 6
+
+                RowLayout {
+                    spacing: 6
+                    Layout.alignment: Qt.AlignHCenter
+
+                    RippleButton {
+                        implicitWidth: 32; implicitHeight: 32
+                        buttonRadius: height / 2
+                        colBackground: Appearance.colors.colSecondaryContainer
+                        onClicked: {
+                            Wallpapers.moveToTop(contextMenu.targetIndex);
+                            contextMenu.visible = false;
+                        }
+                        contentItem: MaterialSymbol {
+                            anchors.centerIn: parent
+                            text: "first_page"
+                            iconSize: Appearance.font.pixelSize.normal
+                            color: Appearance.colors.colOnSecondaryContainer
+                        }
+                        StyledToolTip { text: Translation.tr("Move to beginning") }
+                    }
+
+                    RippleButton {
+                        implicitWidth: 32; implicitHeight: 32
+                        buttonRadius: height / 2
+                        colBackground: Appearance.colors.colSecondaryContainer
+                        onClicked: {
+                            Wallpapers.moveWallpaper(contextMenu.targetIndex, Math.max(0, contextMenu.targetIndex - 1));
+                            contextMenu.visible = false;
+                        }
+                        contentItem: MaterialSymbol {
+                            anchors.centerIn: parent
+                            text: "arrow_back"
+                            iconSize: Appearance.font.pixelSize.normal
+                            color: Appearance.colors.colOnSecondaryContainer
+                        }
+                        StyledToolTip { text: Translation.tr("Move earlier") }
+                    }
+
+                    RippleButton {
+                        implicitWidth: 32; implicitHeight: 32
+                        buttonRadius: height / 2
+                        colBackground: Appearance.colors.colSecondaryContainer
+                        onClicked: {
+                            Wallpapers.moveWallpaper(contextMenu.targetIndex, Math.min(Wallpapers.wallpaperModel.count - 1, contextMenu.targetIndex + 1));
+                            contextMenu.visible = false;
+                        }
+                        contentItem: MaterialSymbol {
+                            anchors.centerIn: parent
+                            text: "arrow_forward"
+                            iconSize: Appearance.font.pixelSize.normal
+                            color: Appearance.colors.colOnSecondaryContainer
+                        }
+                        StyledToolTip { text: Translation.tr("Move later") }
+                    }
+
+                    RippleButton {
+                        implicitWidth: 32; implicitHeight: 32
+                        buttonRadius: height / 2
+                        colBackground: Appearance.colors.colSecondaryContainer
+                        onClicked: {
+                            Wallpapers.moveToBottom(contextMenu.targetIndex);
+                            contextMenu.visible = false;
+                        }
+                        contentItem: MaterialSymbol {
+                            anchors.centerIn: parent
+                            text: "last_page"
+                            iconSize: Appearance.font.pixelSize.normal
+                            color: Appearance.colors.colOnSecondaryContainer
+                        }
+                        StyledToolTip { text: Translation.tr("Move to end") }
+                    }
+                }
+
+                RowLayout {
+                    spacing: 8
+                    Layout.alignment: Qt.AlignHCenter
+
+                    RippleButton {
+                        implicitWidth: 32; implicitHeight: 32
+                        buttonRadius: height / 2
+                        colBackground: Appearance.colors.colErrorContainer
+                        onClicked: {
+                            contextMenu.visible = false;
+                            deleteProc.deleteFile(contextMenu.targetPath);
+                        }
+                        contentItem: MaterialSymbol {
+                            anchors.centerIn: parent
+                            text: "delete"
+                            iconSize: Appearance.font.pixelSize.normal
+                            color: Appearance.colors.colOnErrorContainer
+                        }
+                        StyledToolTip { text: Translation.tr("Delete wallpaper") }
+                    }
+
+                    RippleButton {
+                        implicitWidth: 32; implicitHeight: 32
+                        buttonRadius: height / 2
+                        colBackground: Appearance.colors.colLayer2
+                        onClicked: contextMenu.visible = false
+                        contentItem: MaterialSymbol {
+                            anchors.centerIn: parent
+                            text: "close"
+                            iconSize: Appearance.font.pixelSize.normal
+                            color: Appearance.colors.colOnLayer2
+                        }
+                        StyledToolTip { text: Translation.tr("Cancel") }
+                    }
                 }
             }
-            RippleButton {
-                implicitWidth: 36; implicitHeight: 36
-                buttonRadius: height / 2
-                colBackground: Appearance.colors.colErrorContainer
-                onClicked: {
-                    contextMenu.visible = false
-                    deleteProc.deleteFile(contextMenu.targetPath)
-                }
-                contentItem: MaterialSymbol {
-                    anchors.centerIn: parent
-                    text: "check"
-                    iconSize: Appearance.font.pixelSize.larger
-                    color: Appearance.colors.colPrimary
-                }
+        }
+    }
+
+    // ─── Floating drag ghost ───
+    Item {
+        id: dragGhost
+        visible: root.isDragging && root.draggedItemData !== null
+        z: 120
+        width: grid.cellWidth
+        height: grid.cellHeight
+        x: root.dragX - width / 2
+        y: root.dragY - height / 2
+        scale: 1.05
+        opacity: 0.92
+
+        StyledRectangularShadow {
+            target: dragGhostBg
+        }
+
+        Rectangle {
+            id: dragGhostBg
+            anchors.fill: parent
+            radius: Appearance.rounding.normal
+            color: Appearance.colors.colLayer2
+            border.width: 2
+            border.color: Appearance.colors.colPrimary
+
+            WallpaperDirectoryItem {
+                anchors.fill: parent
+                fileModelData: root.draggedItemData ? root.draggedItemData : ({})
+                colBackground: Appearance.colors.colSecondaryContainer
+                colText: Appearance.colors.colOnSecondaryContainer
             }
         }
     }
@@ -116,7 +332,7 @@ Item {
     GridView {
         id: grid
         anchors.fill: parent
-        visible: Wallpapers.folderModel.count > 0
+        visible: Wallpapers.wallpaperModel.count > 0
 
         readonly property int columns: root.columns
         readonly property int rows: Math.max(1, Math.ceil(count / columns))
@@ -125,65 +341,148 @@ Item {
         cellWidth: width / root.columns
         cellHeight: cellWidth / root.previewCellAspectRatio
         interactive: true
+        acceptedButtons: Qt.NoButton // Disables mouse-hold flicking/dragging; scrolls ONLY via wheel or trackpad
         clip: true
         keyNavigationWraps: true
         boundsBehavior: Flickable.StopAtBounds
         ScrollBar.vertical: StyledScrollBar {}
 
+        function getModelProp(idx, prop) {
+            if (!grid.model || idx < 0 || idx >= grid.model.count) return prop === "fileIsDir" ? false : "";
+            const item = grid.model.get(idx);
+            if (!item) return prop === "fileIsDir" ? false : "";
+            return (typeof item[prop] !== "undefined") ? item[prop] : (typeof grid.model.get(idx, prop) !== "undefined" ? grid.model.get(idx, prop) : "");
+        }
+
         function moveSelection(delta) {
             currentIndex = Math.max(0, Math.min(grid.model.count - 1, currentIndex + delta));
             positionViewAtIndex(currentIndex, GridView.Contain);
-            const filePath = grid.model.get(currentIndex, "filePath");
-            const isDir = grid.model.get(currentIndex, "fileIsDir");
+            const filePath = getModelProp(currentIndex, "filePath");
+            const isDir = getModelProp(currentIndex, "fileIsDir");
             if (!isDir && filePath && Config.options.background.enableWallpaperPreview) Wallpapers.startPreview(filePath);
         }
 
         function activateCurrent() {
-            const filePath = grid.model.get(currentIndex, "filePath");
+            const filePath = getModelProp(currentIndex, "filePath");
             root.wallpaperSelected(filePath);
         }
 
-        model: Wallpapers.folderModel
+        model: Wallpapers.wallpaperModel
         onModelChanged: { currentIndex = 0; Wallpapers.stopPreview(); }
 
-        delegate: WallpaperDirectoryItem {
+        delegate: Item {
+            id: delegateCell
             required property var modelData
             required property int index
-            fileModelData: modelData
             width: grid.cellWidth
             height: grid.cellHeight
-            colBackground: (index === grid?.currentIndex || containsMouse)
-                ? Appearance.colors.colPrimary
-                : (fileModelData.filePath === Config.options.background.wallpaperPath)
-                    ? Appearance.colors.colSecondaryContainer
-                    : ColorUtils.transparentize(Appearance.colors.colPrimaryContainer)
-            colText: (index === grid.currentIndex || containsMouse)
-                ? Appearance.colors.colOnPrimary
-                : (fileModelData.filePath === Config.options.background.wallpaperPath)
-                    ? Appearance.colors.colOnSecondaryContainer
-                    : Appearance.colors.colOnLayer0
+
+            readonly property bool isGhost: root.isDragging && root.dragFromIndex === index
+            readonly property bool isDropTarget: root.isDragging && root.dropTargetIndex === index && root.dragFromIndex !== index
+
+            opacity: isGhost ? 0.3 : 1.0
+            scale: isDropTarget ? 1.05 : 1.0
+            Behavior on scale { NumberAnimation { duration: 150; easing.type: Easing.OutQuad } }
+            Behavior on opacity { NumberAnimation { duration: 150 } }
+
+            WallpaperDirectoryItem {
+                id: wallpaperItem
+                anchors.fill: parent
+                fileModelData: delegateCell.modelData
+                colBackground: (delegateCell.index === grid.currentIndex || cellMouseArea.containsMouse)
+                    ? Appearance.colors.colPrimary
+                    : (delegateCell.modelData.filePath === Config.options.background.wallpaperPath)
+                        ? Appearance.colors.colSecondaryContainer
+                        : ColorUtils.transparentize(Appearance.colors.colPrimaryContainer)
+                colText: (delegateCell.index === grid.currentIndex || cellMouseArea.containsMouse)
+                    ? Appearance.colors.colOnPrimary
+                    : (delegateCell.modelData.filePath === Config.options.background.wallpaperPath)
+                        ? Appearance.colors.colOnSecondaryContainer
+                        : Appearance.colors.colOnLayer0
+            }
+
+            // Drop target indicator
+            Rectangle {
+                anchors.fill: parent
+                anchors.margins: Appearance.sizes.wallpaperSelectorItemMargins
+                radius: Appearance.rounding.normal
+                color: "transparent"
+                border.width: 2
+                border.color: Appearance.colors.colPrimary
+                visible: delegateCell.isDropTarget
+                z: 2
+            }
 
             MouseArea {
+                id: cellMouseArea
                 anchors.fill: parent
-                acceptedButtons: Qt.RightButton
-                z: 2
-                onClicked: event => {
-                    if (event.button === Qt.RightButton) {
-                        var pos = mapToItem(contextMenu.parent, 0, 0)
-                        contextMenu.targetX = pos.x
-                        contextMenu.targetY = pos.y
-                        contextMenu.targetPath = modelData.filePath
-                        contextMenu.visible = true
+                hoverEnabled: true
+                acceptedButtons: Qt.LeftButton | Qt.RightButton
+
+                property real startPressX: 0
+                property real startPressY: 0
+                property bool dragInitiated: false
+
+                onEntered: {
+                    if (!root.isDragging) {
+                        grid.currentIndex = delegateCell.index;
+                    }
+                }
+
+                onPressed: (mouse) => {
+                    if (mouse.button === Qt.LeftButton) {
+                        startPressX = mouse.x;
+                        startPressY = mouse.y;
+                        dragInitiated = false;
+                    }
+                }
+
+                onPositionChanged: (mouse) => {
+                    if (mouse.buttons & Qt.LeftButton) {
+                        if (!root.isDragging) {
+                            const dist = Math.hypot(mouse.x - startPressX, mouse.y - startPressY);
+                            if (dist > 8) {
+                                dragInitiated = true;
+                                root.startDrag(delegateCell.index, delegateCell.modelData, cellMouseArea.mapToItem(root, mouse.x, mouse.y));
+                            }
+                        } else {
+                            root.updateDrag(cellMouseArea.mapToItem(root, mouse.x, mouse.y));
+                        }
+                    }
+                }
+
+                onReleased: (mouse) => {
+                    if (mouse.button === Qt.RightButton) {
+                        const pos = cellMouseArea.mapToItem(contextMenu.parent, 0, 0);
+                        contextMenu.targetX = pos.x;
+                        contextMenu.targetY = pos.y;
+                        contextMenu.targetPath = delegateCell.modelData.filePath;
+                        contextMenu.targetIndex = delegateCell.index;
+                        contextMenu.visible = true;
+                        return;
+                    }
+                    if (root.isDragging) {
+                        root.endDrag();
+                    } else if (!dragInitiated) {
+                        grid.currentIndex = delegateCell.index;
+                        if (GlobalStates.wallpaperSelectorTarget === "lockWall" || !Config.options.background.enableWallpaperPreview) {
+                            root.wallpaperSelected(delegateCell.modelData.filePath);
+                        } else {
+                            if (!delegateCell.modelData.fileIsDir && Config.options.background.enableWallpaperPreview) {
+                                Wallpapers.startPreview(delegateCell.modelData.filePath);
+                            }
+                        }
+                    }
+                }
+
+                onCanceled: root.cancelDrag()
+
+                onDoubleClicked: (mouse) => {
+                    if (mouse.button === Qt.LeftButton) {
+                        root.wallpaperSelected(delegateCell.modelData.filePath);
                     }
                 }
             }
-
-            onEntered: grid.currentIndex = index
-            onPreviewRequested: {
-                grid.currentIndex = index;
-                if (!fileModelData.fileIsDir && Config.options.background.enableWallpaperPreview) Wallpapers.startPreview(fileModelData.filePath);
-            }
-            onActivated: root.wallpaperSelected(fileModelData.filePath)
         }
 
         layer.enabled: true

--- a/modules/ii/wallpaperSelector/OnlineWallpaperGrid.qml
+++ b/modules/ii/wallpaperSelector/OnlineWallpaperGrid.qml
@@ -201,6 +201,7 @@ Item {
             cellWidth: width / root.columns
             cellHeight: cellWidth / root.previewCellAspectRatio
             interactive: true
+            acceptedButtons: Qt.NoButton
             clip: true
             boundsBehavior: Flickable.StopAtBounds
 

--- a/modules/ii/wallpaperSelector/WallpaperDirectoryItem.qml
+++ b/modules/ii/wallpaperSelector/WallpaperDirectoryItem.qml
@@ -7,12 +7,12 @@ import qs.modules.common.widgets
 import qs.services
 import qs
 
-MouseArea {
+Item {
     id: root
 
     required property var fileModelData
-    property bool isDirectory: fileModelData.fileIsDir
-    property bool useThumbnail: Images.isValidImageByName(fileModelData.fileName)
+    property bool isDirectory: fileModelData ? Boolean(fileModelData.fileIsDir) : false
+    property bool useThumbnail: fileModelData ? Images.isValidImageByName(fileModelData.fileName) : false
     property alias colBackground: background.color
     property alias colText: wallpaperItemName.color
     property alias radius: background.radius
@@ -25,14 +25,6 @@ MouseArea {
 
     margins: Appearance.sizes.wallpaperSelectorItemMargins
     padding: Appearance.sizes.wallpaperSelectorItemPadding
-    hoverEnabled: true
-    onClicked: {
-        if (GlobalStates.wallpaperSelectorTarget === "lockWall" || !Config.options.background.enableWallpaperPreview)
-            root.activated()
-        else
-            root.previewRequested()
-    }
-    onDoubleClicked: root.activated()
 
     Rectangle {
         id: background
@@ -76,7 +68,7 @@ MouseArea {
                         id: thumbnailImage
 
                         generateThumbnail: false
-                        sourcePath: fileModelData.filePath
+                        sourcePath: (fileModelData && fileModelData.filePath) ? fileModelData.filePath : ""
                         cache: false
                         fillMode: Image.PreserveAspectCrop
                         clip: true
@@ -150,7 +142,7 @@ MouseArea {
                 horizontalAlignment: Text.AlignHCenter
                 elide: Text.ElideRight
                 font.pixelSize: Appearance.font.pixelSize.smaller
-                text: fileModelData.fileName
+                text: (fileModelData && fileModelData.fileName) ? fileModelData.fileName : ""
 
                 Behavior on color {
                     animation: Appearance.animation.elementMoveFast.colorAnimation.createObject(this)

--- a/modules/ii/wallpaperSelector/WallpaperSelectorContent.qml
+++ b/modules/ii/wallpaperSelector/WallpaperSelectorContent.qml
@@ -431,6 +431,111 @@ MouseArea {
                         }
                     }
 
+                    MouseArea {
+                        id: sortMenuDismissArea
+                        anchors.fill: parent
+                        visible: sortMenuPopup.visible
+                        z: 9
+                        acceptedButtons: Qt.LeftButton | Qt.RightButton
+                        onClicked: sortMenuPopup.visible = false
+                    }
+
+                    Item {
+                        id: sortMenuPopup
+                        visible: false
+                        z: 10
+                        anchors.bottom: extraOptions.top
+                        anchors.horizontalCenter: extraOptions.horizontalCenter
+                        anchors.bottomMargin: 8
+                        implicitWidth: sortMenuContent.implicitWidth + 24
+                        implicitHeight: sortMenuContent.implicitHeight + 20
+
+                        StyledRectangularShadow {
+                            target: sortMenuBackground
+                        }
+
+                        Rectangle {
+                            id: sortMenuBackground
+                            anchors.fill: parent
+                            radius: Appearance.rounding.normal
+                            color: Appearance.colors.colLayer1
+                            border.width: 1
+                            border.color: Appearance.colors.colLayer0Border
+
+                            ColumnLayout {
+                                id: sortMenuContent
+                                anchors.centerIn: parent
+                                spacing: 3
+
+                                StyledText {
+                                    Layout.fillWidth: true
+                                    Layout.leftMargin: 10
+                                    Layout.rightMargin: 10
+                                    Layout.topMargin: 4
+                                    Layout.bottomMargin: 2
+                                    text: Translation.tr("Sort wallpapers")
+                                    font.pixelSize: Appearance.font.pixelSize.smaller
+                                    color: Appearance.colors.colSubtext
+                                }
+
+                                Repeater {
+                                    model: [
+                                        { id: "custom",   name: Translation.tr("Custom (manual order)"), icon: "dashboard_customize" },
+                                        { id: "time",     name: Translation.tr("Date added (newest first)"), icon: "schedule" },
+                                        { id: "time_rev", name: Translation.tr("Date added (oldest first)"), icon: "history" },
+                                        { id: "name",     name: Translation.tr("Name (A to Z)"), icon: "sort_by_alpha" },
+                                        { id: "name_rev", name: Translation.tr("Name (Z to A)"), icon: "sort_by_alpha" },
+                                        { id: "size",     name: Translation.tr("Size (largest first)"), icon: "straighten" },
+                                        { id: "size_rev", name: Translation.tr("Size (smallest first)"), icon: "straighten" },
+                                    ]
+
+                                    delegate: RippleButton {
+                                        id: sortItemBtn
+                                        required property var modelData
+                                        implicitHeight: 32
+                                        implicitWidth: 230
+                                        buttonRadius: Appearance.rounding.small
+                                        toggled: Wallpapers.sortMode === modelData.id
+                                        colBackgroundToggled: Appearance.colors.colSecondaryContainer
+                                        colBackgroundToggledHover: Appearance.colors.colSecondaryContainerHover
+                                        colRippleToggled: Appearance.colors.colSecondaryContainerActive
+                                        onClicked: {
+                                            Wallpapers.setSortMode(modelData.id);
+                                            sortMenuPopup.visible = false;
+                                        }
+
+                                        contentItem: RowLayout {
+                                            anchors.fill: parent
+                                            anchors.leftMargin: 10
+                                            anchors.rightMargin: 10
+                                            spacing: 8
+
+                                            MaterialSymbol {
+                                                text: sortItemBtn.modelData.icon
+                                                iconSize: Appearance.font.pixelSize.normal
+                                                color: sortItemBtn.toggled ? Appearance.colors.colOnSecondaryContainer : Appearance.colors.colOnLayer1
+                                            }
+
+                                            StyledText {
+                                                Layout.fillWidth: true
+                                                text: sortItemBtn.modelData.name
+                                                font.pixelSize: Appearance.font.pixelSize.small
+                                                color: sortItemBtn.toggled ? Appearance.colors.colOnSecondaryContainer : Appearance.colors.colOnLayer1
+                                            }
+
+                                            MaterialSymbol {
+                                                visible: sortItemBtn.toggled
+                                                text: "check"
+                                                iconSize: Appearance.font.pixelSize.small
+                                                color: Appearance.colors.colPrimary
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
                     RowLayout {
                         id: extraOptions
                         anchors {
@@ -495,6 +600,15 @@ MouseArea {
                                     text: "reset_image"
                                     StyledToolTip {
                                         text: Translation.tr("Update thumbnails")
+                                    }
+                                }
+                                IconToolbarButton {
+                                    implicitWidth: height
+                                    toggled: sortMenuPopup.visible
+                                    onClicked: sortMenuPopup.visible = !sortMenuPopup.visible
+                                    text: "sort"
+                                    StyledToolTip {
+                                        text: Translation.tr("Sort wallpapers")
                                     }
                                 }
                                 ToolbarTextField {
@@ -582,6 +696,7 @@ MouseArea {
                 else
                     root.forceActiveFocus()
             } else if (!GlobalStates.wallpaperSelectorOpen) {
+                sortMenuPopup.visible = false;
                 Wallpapers.stopPreview();
             }
         }

--- a/services/Wallpapers.qml
+++ b/services/Wallpapers.qml
@@ -21,6 +21,9 @@ Singleton {
     readonly property string effectiveDirectory: FileUtils.trimFileProtocol(folderModel.folder.toString())
     property url defaultFolder: Qt.resolvedUrl(`${Directories.pictures}/Wallpapers`)
     property alias folderModel: folderModel // Expose for direct binding when needed
+    property alias wallpaperModel: wallpaperModel
+    property string sortMode: Config.options.wallpaperSelector?.sortMode || "custom"
+    property var orderMap: ({})
     property string searchQuery: ""
     readonly property list<string> extensions: [ // TODO: add videos
         "jpg", "jpeg", "png", "webp", "avif", "bmp", "svg"
@@ -95,19 +98,23 @@ Singleton {
     }
 
     function randomFromCurrentFolder(darkMode = Appearance.m3colors.darkmode) {
-        if (folderModel.count === 0) return;
-        const randomIndex = Math.floor(Math.random() * folderModel.count);
-        const filePath = folderModel.get(randomIndex, "filePath");
+        const count = wallpaperModel.count > 0 ? wallpaperModel.count : folderModel.count;
+        if (count === 0) return;
+        const randomIndex = Math.floor(Math.random() * count);
+        const item = wallpaperModel.count > 0 ? wallpaperModel.get(randomIndex) : null;
+        const filePath = item ? item.filePath : folderModel.get(randomIndex, "filePath");
         print("Randomly selected wallpaper:", filePath);
-        root.select(filePath, darkMode);
+        if (filePath) root.select(filePath, darkMode);
     }
 
     function getRandomWallpaperPath(excludePath = "") {
-        if (folderModel.count === 0) return "";
+        const count = wallpaperModel.count > 0 ? wallpaperModel.count : folderModel.count;
+        if (count === 0) return "";
         const excludeClean = FileUtils.trimFileProtocol(excludePath);
         const candidates = [];
-        for (let i = 0; i < folderModel.count; i++) {
-            const path = folderModel.get(i, "filePath") || FileUtils.trimFileProtocol(folderModel.get(i, "fileURL"));
+        for (let i = 0; i < count; i++) {
+            const item = wallpaperModel.count > 0 ? wallpaperModel.get(i) : null;
+            const path = item ? item.filePath : (folderModel.get(i, "filePath") || FileUtils.trimFileProtocol(folderModel.get(i, "fileURL")));
             if (path && path.length && FileUtils.trimFileProtocol(path) !== excludeClean) {
                 candidates.push(path);
             }
@@ -164,13 +171,197 @@ Singleton {
         showOnlyReadable: true
         sortField: FolderListModel.Time
         sortReversed: false
-        onCountChanged: {
-            root.wallpapers = []
-            for (let i = 0; i < folderModel.count; i++) {
-                const path = folderModel.get(i, "filePath") || FileUtils.trimFileProtocol(folderModel.get(i, "fileURL"))
-                if (path && path.length) root.wallpapers.push(path)
+        onCountChanged: debounceRebuildTimer.restart()
+        onStatusChanged: {
+            if (status === FolderListModel.Ready) debounceRebuildTimer.restart();
+        }
+    }
+
+    onEffectiveDirectoryChanged: debounceRebuildTimer.restart()
+    onSearchQueryChanged: debounceRebuildTimer.restart()
+
+    ListModel {
+        id: wallpaperModel
+    }
+
+    FileView {
+        id: orderFileView
+        path: `${Directories.shellConfig}/wallpaper_order.json`
+        watchChanges: false
+        onLoaded: {
+            try {
+                const txt = orderFileView.text();
+                if (txt && txt.trim().length > 0) {
+                    root.orderMap = JSON.parse(txt);
+                } else {
+                    root.orderMap = {};
+                }
+            } catch (e) {
+                console.log("[Wallpapers] Error parsing wallpaper_order.json:", e);
+                root.orderMap = {};
+            }
+            debounceRebuildTimer.restart();
+        }
+        onLoadFailed: (error) => {
+            root.orderMap = {};
+            debounceRebuildTimer.restart();
+        }
+    }
+
+    function saveCustomOrder() {
+        if (!orderFileView) return;
+        try {
+            orderFileView.setText(JSON.stringify(root.orderMap, null, 2));
+        } catch (e) {
+            console.log("[Wallpapers] Failed to save wallpaper_order.json:", e);
+        }
+    }
+
+    function moveWallpaper(fromIndex, toIndex) {
+        if (fromIndex < 0 || toIndex < 0 || fromIndex >= wallpaperModel.count || toIndex >= wallpaperModel.count || fromIndex === toIndex)
+            return;
+
+        wallpaperModel.move(fromIndex, toIndex, 1);
+        root.sortMode = "custom";
+        if (Config.options.wallpaperSelector) {
+            Config.options.wallpaperSelector.sortMode = "custom";
+        }
+
+        const list = [];
+        const paths = [];
+        for (let i = 0; i < wallpaperModel.count; i++) {
+            const it = wallpaperModel.get(i);
+            list.push(it.fileName);
+            if (it.filePath) paths.push(it.filePath);
+        }
+        root.orderMap[root.effectiveDirectory] = list;
+        root.wallpapers = paths;
+        root.saveCustomOrder();
+    }
+
+    function moveToTop(index) {
+        moveWallpaper(index, 0);
+    }
+
+    function moveToBottom(index) {
+        moveWallpaper(index, wallpaperModel.count - 1);
+    }
+
+    function setSortMode(mode) {
+        root.sortMode = mode;
+        if (Config.options.wallpaperSelector) {
+            Config.options.wallpaperSelector.sortMode = mode;
+        }
+        rebuildWallpaperModel();
+    }
+
+    Timer {
+        id: debounceRebuildTimer
+        interval: 20
+        repeat: false
+        onTriggered: root.rebuildWallpaperModel()
+    }
+
+    function sortItems(items, mode, customList) {
+        if (mode === "custom") {
+            if (!customList || customList.length === 0) {
+                return items.slice().sort((a, b) => {
+                    if (a.fileIsDir !== b.fileIsDir) return a.fileIsDir ? -1 : 1;
+                    return new Date(b.fileModified) - new Date(a.fileModified);
+                });
+            }
+            const orderLookup = {};
+            for (let i = 0; i < customList.length; i++) {
+                orderLookup[customList[i]] = i;
+            }
+            const ordered = [];
+            const remaining = [];
+            for (let i = 0; i < items.length; i++) {
+                const it = items[i];
+                if (typeof orderLookup[it.fileName] !== "undefined") {
+                    ordered.push(it);
+                } else {
+                    remaining.push(it);
+                }
+            }
+            ordered.sort((a, b) => orderLookup[a.fileName] - orderLookup[b.fileName]);
+            return remaining.concat(ordered).sort((a, b) => {
+                if (a.fileIsDir !== b.fileIsDir) return a.fileIsDir ? -1 : 1;
+                return 0;
+            });
+        } else if (mode === "name") {
+            return items.slice().sort((a, b) => {
+                if (a.fileIsDir !== b.fileIsDir) return a.fileIsDir ? -1 : 1;
+                return a.fileName.localeCompare(b.fileName, undefined, { numeric: true, sensitivity: "base" });
+            });
+        } else if (mode === "name_rev") {
+            return items.slice().sort((a, b) => {
+                if (a.fileIsDir !== b.fileIsDir) return a.fileIsDir ? -1 : 1;
+                return b.fileName.localeCompare(a.fileName, undefined, { numeric: true, sensitivity: "base" });
+            });
+        } else if (mode === "time") {
+            return items.slice().sort((a, b) => {
+                if (a.fileIsDir !== b.fileIsDir) return a.fileIsDir ? -1 : 1;
+                return new Date(b.fileModified) - new Date(a.fileModified);
+            });
+        } else if (mode === "time_rev") {
+            return items.slice().sort((a, b) => {
+                if (a.fileIsDir !== b.fileIsDir) return a.fileIsDir ? -1 : 1;
+                return new Date(a.fileModified) - new Date(b.fileModified);
+            });
+        } else if (mode === "size") {
+            return items.slice().sort((a, b) => {
+                if (a.fileIsDir !== b.fileIsDir) return a.fileIsDir ? -1 : 1;
+                return (b.fileSize || 0) - (a.fileSize || 0);
+            });
+        } else if (mode === "size_rev") {
+            return items.slice().sort((a, b) => {
+                if (a.fileIsDir !== b.fileIsDir) return a.fileIsDir ? -1 : 1;
+                return (a.fileSize || 0) - (b.fileSize || 0);
+            });
+        }
+        return items;
+    }
+
+    function rebuildWallpaperModel() {
+        const count = folderModel.count;
+        if (count === 0) {
+            wallpaperModel.clear();
+            root.wallpapers = [];
+            return;
+        }
+
+        const items = [];
+        for (let i = 0; i < count; i++) {
+            const fn = folderModel.get(i, "fileName") || "";
+            const fp = folderModel.get(i, "filePath") || "";
+            const fu = (fp && fp.length) ? ("file://" + fp) : (folderModel.get(i, "fileUrl") || "");
+            const isDir = Boolean(folderModel.get(i, "fileIsDir"));
+            const sz = folderModel.get(i, "fileSize") || 0;
+            const mod = folderModel.get(i, "fileModified") ? folderModel.get(i, "fileModified").toString() : "";
+            items.push({
+                fileName: fn,
+                filePath: fp,
+                fileUrl: fu,
+                fileURL: fu,
+                fileIsDir: isDir,
+                fileSize: sz,
+                fileModified: mod
+            });
+        }
+
+        const savedOrder = root.orderMap[root.effectiveDirectory] || [];
+        const sorted = sortItems(items, root.sortMode, savedOrder);
+
+        wallpaperModel.clear();
+        const paths = [];
+        for (let i = 0; i < sorted.length; i++) {
+            wallpaperModel.append(sorted[i]);
+            if (sorted[i].filePath && sorted[i].filePath.length) {
+                paths.push(sorted[i].filePath);
             }
         }
+        root.wallpapers = paths;
     }
 
     // Thumbnail generation
@@ -216,6 +407,14 @@ Singleton {
 
         function apply(path: string): void {
             root.apply(path);
+        }
+
+        function setSortMode(mode: string): void {
+            root.setSortMode(mode);
+        }
+
+        function moveWallpaper(fromIndex: int, toIndex: int): void {
+            root.moveWallpaper(fromIndex, toIndex);
         }
     }
 }


### PR DESCRIPTION
**Manual Reordering:**
      - Drag-and-drop wallpaper reordering with target slot highlight and edge auto-scrolling.  
      - Context menu buttons (Top, Left, Right, Bottom) to reorder items without dragging.      
      - Persistent custom order per directory saved to `~/.config/illogical-impulse/wallpaper_order.json`.
**Sorting Options:**
      - Added a sort menu to the toolbar with modes: Custom, Name (A-Z / Z-A), Date Modified (Newest / Oldest), and File Size.
      - Configurable `sortMode` in `Config.qml`.
  
**Bug Fixes:**
      - Disabled interactive flick-scrolling in `GridView` with mouse drag (`acceptedButtons: Qt.NoButton`) so dragging wallpapers doesn't trigger unwanted list scrolling.
      - Fixed an issue where dropping a wallpaper prematurely closed the selector window.       
      - Added null safety checks in `WallpaperDirectoryItem.qml`.