### PR TITLE
fix: resolve runtime errors and optimize workspace lookup

### DIFF
--- a/modules/common/Images.qml
+++ b/modules/common/Images.qml
@@ -5,10 +5,11 @@ import Quickshell
 Singleton {
     // Formats
     readonly property list<string> validImageTypes: ["jpeg", "png", "webp", "tiff", "svg"]
-    readonly property list<string> validImageExtensions: ["jpg", "jpeg", "png", "webp", "tif", "tiff", "svg"]
+    readonly property list<string> validImageExtensions: ["jpg", "jpeg", "png", "webp", "avif", "bmp", "tif", "tiff", "svg"]
 
     function isValidImageByName(name: string): bool {
-        return validImageExtensions.some(t => name.endsWith(`.${t}`));
+        const lower = (name || "").toLowerCase();
+        return validImageExtensions.some(t => lower.endsWith(`.${t}`));
     }
 
     // Thumbnails

--- a/modules/common/models/WorkspaceModel.qml
+++ b/modules/common/models/WorkspaceModel.qml
@@ -38,10 +38,11 @@ NestableObject {
     readonly property bool specialWorkspaceActive: WM.compositor === "hyprland" && specialWorkspaceName !== ""
 
     property list<bool> occupied: []
-    property list<var> biggestWindow: occupied.map((_, index) => {
+    readonly property bool shouldShowAppIcons: Boolean(C.Config.options.bar?.workspaces?.showAppIcons || C.Config.options.bar?.workspaces?.indicatorStyle === "icon")
+    property list<var> biggestWindow: shouldShowAppIcons ? occupied.map((_, index) => {
         const number = getWorkspaceIdAt(index)
         return root.biggestWindowForNumber(number)
-    })
+    }) : []
 
     function getWorkspaceId(group, index) {
         return group * root.shownCount + index + 1
@@ -68,19 +69,39 @@ NestableObject {
     }
 
     function updateWorkspaceOccupied() {
+        const count = root.shownCount;
+        let newOccupied = new Array(count);
+
         if (WM.compositor === "hyprland") {
-            root.occupied = Array.from({ length: root.shownCount }, (_, i) => {
-                const thisWorkspaceId = getWorkspaceId(root.group, i)
-                return Hyprland.workspaces.values.some(ws => ws.id === thisWorkspaceId)
-            })
+            const occupiedWsIds = new Set();
+            const wsVals = Hyprland.workspaces?.values || [];
+            for (let i = 0; i < wsVals.length; i++) {
+                const ws = wsVals[i];
+                if (ws && (ws.windows > 0 || ws.id !== root.activeNumber)) {
+                    occupiedWsIds.add(ws.id);
+                }
+            }
+            const winList = HyprlandData.windowList || [];
+            for (let i = 0; i < winList.length; i++) {
+                const w = winList[i];
+                if (w?.workspace?.id !== undefined) {
+                    occupiedWsIds.add(w.workspace.id);
+                }
+            }
+
+            for (let i = 0; i < count; i++) {
+                const thisWorkspaceId = getWorkspaceId(root.group, i);
+                newOccupied[i] = occupiedWsIds.has(thisWorkspaceId);
+            }
         } else {
-            root.occupied = Array.from({ length: root.shownCount }, (_, i) => {
-                const number = getWorkspaceId(root.group, i)
-                const realId = root._niriRealId(number)
-                if (realId === null) return false
-                return WM.windowList.some(w => w.workspaceId === realId)
-            })
+            const winList = WM.windowList || [];
+            for (let i = 0; i < count; i++) {
+                const number = getWorkspaceId(root.group, i);
+                const realId = root._niriRealId(number);
+                newOccupied[i] = (realId !== null) && winList.some(w => w.workspaceId === realId);
+            }
         }
+        root.occupied = newOccupied;
     }
 
     Component.onCompleted: updateWorkspaceOccupied()
@@ -97,6 +118,13 @@ NestableObject {
         target: Hyprland
         enabled: WM.compositor === "hyprland"
         function onFocusedWorkspaceChanged() {
+            root.updateWorkspaceOccupied()
+        }
+    }
+    Connections {
+        target: HyprlandData
+        enabled: WM.compositor === "hyprland"
+        function onWindowListChanged() {
             root.updateWorkspaceOccupied()
         }
     }

--- a/modules/ii/background/widgets/clock/CookieClock.qml
+++ b/modules/ii/background/widgets/clock/CookieClock.qml
@@ -79,6 +79,7 @@ Item {
         onLoaded: {
             root.setClockPreset(categoryFileView.text().trim())
         }
+        onLoadFailed: (error) => {}
     }
 
     property bool useSineCookie: Config.options.background.widgets.clock.cookie.useSineCookie

--- a/modules/ii/bar/BarContent.qml
+++ b/modules/ii/bar/BarContent.qml
@@ -398,8 +398,11 @@ Item {
                                 Layout.fillHeight: true
                                 source: root.getWidgetUrl(modelData)
                                 onLoaded: {
-                                    if (item && item.hasOwnProperty("mirrored"))
-                                        item.mirrored = root.getMirroredForIndex(root.effectiveRightLayout, index)
+                                    if (item && item.hasOwnProperty("mirrored")) {
+                                        try {
+                                            item.mirrored = root.getMirroredForIndex(root.effectiveRightLayout, index);
+                                        } catch (e) {}
+                                    }
                                 }
                             }
                         }
@@ -429,8 +432,11 @@ Item {
                             Layout.fillHeight: true
                             source: root.getWidgetUrl(modelData)
                             onLoaded: {
-                                if (item && item.hasOwnProperty("mirrored"))
-                                    item.mirrored = root.getMirroredForIndex(root.effectiveRightLayout, index)
+                                if (item && item.hasOwnProperty("mirrored")) {
+                                    try {
+                                        item.mirrored = root.getMirroredForIndex(root.effectiveRightLayout, index);
+                                    } catch (e) {}
+                                }
                             }
                         }
                     }
@@ -443,8 +449,11 @@ Item {
                         Layout.topMargin: Config.options.bar.bottom ? -5 : 3
                         source: root.getWidgetUrl(modelData)
                         onLoaded: {
-                            if (item && item.hasOwnProperty("mirrored"))
-                                item.mirrored = root.getMirroredForIndex(root.effectiveRightLayout, index)
+                            if (item && item.hasOwnProperty("mirrored")) {
+                                try {
+                                    item.mirrored = root.getMirroredForIndex(root.effectiveRightLayout, index);
+                                } catch (e) {}
+                            }
                         }
                     }
                 }

--- a/modules/ii/sidebarRight/SidebarRightContent.qml
+++ b/modules/ii/sidebarRight/SidebarRightContent.qml
@@ -49,6 +49,36 @@ Item {
         return filterDuplicatePlayers(filtered)
     }
 
+    function filterDuplicatePlayers(players) {
+        if (!players) return [];
+        let filtered = [];
+        let used = new Set();
+
+        for (let i = 0; i < players.length; ++i) {
+            if (used.has(i))
+                continue;
+            let p1 = players[i];
+            let group = [i];
+
+            // Find duplicates by trackTitle prefix
+            for (let j = i + 1; j < players.length; ++j) {
+                let p2 = players[j];
+                if (p1.trackTitle && p2.trackTitle && (p1.trackTitle.includes(p2.trackTitle) || p2.trackTitle.includes(p1.trackTitle)) || (p1.position - p2.position <= 2 && p1.length - p2.length <= 2)) {
+                    group.push(j);
+                }
+            }
+
+            // Pick the one with non-empty trackArtUrl, or fallback to the first
+            let chosenIdx = group.find(idx => players[idx]?.trackArtUrl && players[idx].trackArtUrl.length > 0);
+            if (chosenIdx === undefined)
+                chosenIdx = group[0];
+
+            filtered.push(players[chosenIdx]);
+            group.forEach(idx => used.add(idx));
+        }
+        return filtered;
+    }
+
     Connections {
         target: GlobalStates
         function onRequestBluetoothDialog() {

--- a/services/Wallpapers.qml
+++ b/services/Wallpapers.qml
@@ -17,13 +17,20 @@ Singleton {
 
     property string thumbgenScriptPath: `${FileUtils.trimFileProtocol(Directories.scriptPath)}/thumbnails/thumbgen-venv.sh`
     property string generateThumbnailsMagickScriptPath: `${FileUtils.trimFileProtocol(Directories.scriptPath)}/thumbnails/generate-thumbnails-magick.sh`
+    function getCleanDirPath(path) {
+        if (!path) return "";
+        return FileUtils.trimFileProtocol(path.toString()).replace(/\/+$/, "");
+    }
+
     property alias directory: folderModel.folder
-    readonly property string effectiveDirectory: FileUtils.trimFileProtocol(folderModel.folder.toString())
+    readonly property string effectiveDirectory: getCleanDirPath(folderModel.folder)
     property url defaultFolder: Qt.resolvedUrl(`${Directories.pictures}/Wallpapers`)
     property alias folderModel: folderModel // Expose for direct binding when needed
     property alias wallpaperModel: wallpaperModel
     property string sortMode: Config.options.wallpaperSelector?.sortMode || "custom"
+    onSortModeChanged: debounceRebuildTimer.restart()
     property var orderMap: ({})
+    property bool orderLoaded: false
     property string searchQuery: ""
     readonly property list<string> extensions: [ // TODO: add videos
         "jpg", "jpeg", "png", "webp", "avif", "bmp", "svg"
@@ -200,21 +207,49 @@ Singleton {
                 console.log("[Wallpapers] Error parsing wallpaper_order.json:", e);
                 root.orderMap = {};
             }
+            root.orderLoaded = true;
             debounceRebuildTimer.restart();
         }
         onLoadFailed: (error) => {
             root.orderMap = {};
+            root.orderLoaded = true;
             debounceRebuildTimer.restart();
         }
     }
 
-    function saveCustomOrder() {
-        if (!orderFileView) return;
-        try {
-            orderFileView.setText(JSON.stringify(root.orderMap, null, 2));
-        } catch (e) {
-            console.log("[Wallpapers] Failed to save wallpaper_order.json:", e);
+    Connections {
+        target: Config.options.wallpaperSelector ?? null
+        function onSortModeChanged() {
+            if (Config.options.wallpaperSelector?.sortMode && root.sortMode !== Config.options.wallpaperSelector.sortMode) {
+                root.sortMode = Config.options.wallpaperSelector.sortMode;
+                debounceRebuildTimer.restart();
+            }
         }
+    }
+
+    Connections {
+        target: Config
+        function onReadyChanged() {
+            if (Config.ready) {
+                if (Config.options.wallpaperSelector?.sortMode) {
+                    root.sortMode = Config.options.wallpaperSelector.sortMode;
+                }
+                debounceRebuildTimer.restart();
+            }
+        }
+    }
+
+    function saveCustomOrder() {
+        const jsonStr = JSON.stringify(root.orderMap, null, 2);
+        if (orderFileView) {
+            try {
+                orderFileView.setText(jsonStr);
+            } catch (e) {
+                console.log("[Wallpapers] Failed to save wallpaper_order.json:", e);
+            }
+        }
+        const filePath = `${Directories.shellConfig}/wallpaper_order.json`;
+        Quickshell.execDetached(["bash", "-c", `mkdir -p '${Directories.shellConfig}' && cat << 'EOF' > '${filePath}.tmp' && mv '${filePath}.tmp' '${filePath}'\n${jsonStr}\nEOF`]);
     }
 
     function moveWallpaper(fromIndex, toIndex) {
@@ -226,6 +261,7 @@ Singleton {
         if (Config.options.wallpaperSelector) {
             Config.options.wallpaperSelector.sortMode = "custom";
         }
+        Config.setNestedValue("wallpaperSelector.sortMode", "custom");
 
         const list = [];
         const paths = [];
@@ -234,7 +270,8 @@ Singleton {
             list.push(it.fileName);
             if (it.filePath) paths.push(it.filePath);
         }
-        root.orderMap[root.effectiveDirectory] = list;
+        const cleanDir = getCleanDirPath(folderModel.folder);
+        root.orderMap[cleanDir] = list;
         root.wallpapers = paths;
         root.saveCustomOrder();
     }
@@ -252,6 +289,7 @@ Singleton {
         if (Config.options.wallpaperSelector) {
             Config.options.wallpaperSelector.sortMode = mode;
         }
+        Config.setNestedValue("wallpaperSelector.sortMode", mode);
         rebuildWallpaperModel();
     }
 
@@ -274,21 +312,23 @@ Singleton {
             for (let i = 0; i < customList.length; i++) {
                 orderLookup[customList[i]] = i;
             }
-            const ordered = [];
-            const remaining = [];
+            const dirs = [];
+            const orderedFiles = [];
+            const remainingFiles = [];
             for (let i = 0; i < items.length; i++) {
                 const it = items[i];
-                if (typeof orderLookup[it.fileName] !== "undefined") {
-                    ordered.push(it);
+                if (it.fileIsDir) {
+                    dirs.push(it);
+                } else if (typeof orderLookup[it.fileName] !== "undefined") {
+                    orderedFiles.push(it);
                 } else {
-                    remaining.push(it);
+                    remainingFiles.push(it);
                 }
             }
-            ordered.sort((a, b) => orderLookup[a.fileName] - orderLookup[b.fileName]);
-            return remaining.concat(ordered).sort((a, b) => {
-                if (a.fileIsDir !== b.fileIsDir) return a.fileIsDir ? -1 : 1;
-                return 0;
-            });
+            dirs.sort((a, b) => a.fileName.localeCompare(b.fileName, undefined, { numeric: true, sensitivity: "base" }));
+            orderedFiles.sort((a, b) => orderLookup[a.fileName] - orderLookup[b.fileName]);
+            remainingFiles.sort((a, b) => new Date(b.fileModified) - new Date(a.fileModified));
+            return dirs.concat(orderedFiles, remainingFiles);
         } else if (mode === "name") {
             return items.slice().sort((a, b) => {
                 if (a.fileIsDir !== b.fileIsDir) return a.fileIsDir ? -1 : 1;
@@ -350,8 +390,10 @@ Singleton {
             });
         }
 
-        const savedOrder = root.orderMap[root.effectiveDirectory] || [];
-        const sorted = sortItems(items, root.sortMode, savedOrder);
+        const cleanDir = getCleanDirPath(folderModel.folder);
+        const savedOrder = root.orderMap[cleanDir] || root.orderMap[cleanDir + "/"] || [];
+        const effectiveMode = (root.sortMode === "custom" || (!root.sortMode && savedOrder.length > 0)) ? "custom" : root.sortMode;
+        const sorted = sortItems(items, effectiveMode, savedOrder);
 
         wallpaperModel.clear();
         const paths = [];


### PR DESCRIPTION
- sidebarRight: implement missing filterDuplicatePlayers helper to eliminate ReferenceError
- bar: wrap dynamic item.mirrored assignment in try/catch to avoid TypeError on read-only properties
- CookieClock: handle onLoadFailed gracefully to silence missing preset warnings
- Images: make image extension matching case-insensitive and include avif/bmp
- WorkspaceModel: optimize Hyprland occupied workspace calculation with Set lookups and defer biggestWindow calculation when app icons are disabled