### PR TITLE
fix: cookie-clock-rotation

### DIFF
--- a/modules/ii/background/widgets/clock/CookieClock.qml
+++ b/modules/ii/background/widgets/clock/CookieClock.qml
@@ -83,8 +83,9 @@ Item {
     }
 
     property bool useSineCookie: Config.options.background.widgets.clock.cookie.useSineCookie
-    StyledDropShadow {
-        target: root.useSineCookie ? sineCookieLoader : roundedPolygonCookieLoader
+    Item {
+        id: cookieContainer
+        anchors.fill: parent
 
         RotationAnimation on rotation {
             running: Config.options.background.widgets.clock.cookie.constantlyRotate
@@ -94,48 +95,61 @@ Item {
             from: 360
             to: 0
         }
-    }
-    Loader {
-        id: sineCookieLoader
-        z: 0
-        visible: !root.blurWidgets // The DropShadow already draws it when not blurring
-        active: root.useSineCookie
-        sourceComponent: SineCookie {
-            implicitSize: root.implicitSize
-            sides: Config.options.background.widgets.clock.cookie.sides
-            color: root.colBackground
-        }
-    }
-    Loader {
-        id: roundedPolygonCookieLoader
-        z: 0
-        visible: !root.blurWidgets // The DropShadow already draws it when not blurring
-        active: !root.useSineCookie
-        sourceComponent: MaterialCookie {
-            implicitSize: root.implicitSize
-            sides: Config.options.background.widgets.clock.cookie.sides
-            color: root.colBackground
-        }
-    }
 
-    // Blurred wallpaper, masked by the cookie shape
-    FastBlurred {
-        id: cookieBlur
-        anchors.fill: parent
-        blurSource: root.wallpaperItem
-        cardRadius: 0
-        tint: Appearance.colors.colLayer1
-        tintOpacity: 0.55
-        trackX: root.originX + root.x
-        trackY: root.originY + root.y
-        visible: false
-    }
-    OpacityMask {
-        anchors.fill: parent
-        source: cookieBlur
-        maskSource: root.useSineCookie ? sineCookieLoader.item : roundedPolygonCookieLoader.item
-        z: 0
-        visible: root.blurWidgets
+        StyledDropShadow {
+            target: cookieShapes
+            visible: !root.blurWidgets
+        }
+
+        Item {
+            id: cookieShapes
+            anchors.fill: parent
+
+            Loader {
+                id: sineCookieLoader
+                anchors.fill: parent
+                z: 0
+                visible: !root.blurWidgets
+                active: root.useSineCookie
+                sourceComponent: SineCookie {
+                    implicitSize: root.implicitSize
+                    sides: Config.options.background.widgets.clock.cookie.sides
+                    color: root.colBackground
+                }
+            }
+            Loader {
+                id: roundedPolygonCookieLoader
+                anchors.fill: parent
+                z: 0
+                visible: !root.blurWidgets
+                active: !root.useSineCookie
+                sourceComponent: MaterialCookie {
+                    implicitSize: root.implicitSize
+                    sides: Config.options.background.widgets.clock.cookie.sides
+                    color: root.colBackground
+                }
+            }
+        }
+
+        // Blurred wallpaper, masked by the cookie shape
+        FastBlurred {
+            id: cookieBlur
+            anchors.fill: parent
+            blurSource: root.wallpaperItem
+            cardRadius: 0
+            tint: Appearance.colors.colLayer1
+            tintOpacity: 0.55
+            trackX: root.originX + root.x
+            trackY: root.originY + root.y
+            visible: false
+        }
+        OpacityMask {
+            anchors.fill: parent
+            source: cookieBlur
+            maskSource: root.useSineCookie ? sineCookieLoader.item : roundedPolygonCookieLoader.item
+            z: 0
+            visible: root.blurWidgets
+        }
     }
 
     // Hour/minutes numbers/dots/lines


### PR DESCRIPTION
The Cookie Clock displayed a duplicate / ghosted background shape when `constantlyRotate` was enabled.
<img width="252" height="246" alt="archivo pegado" src="https://github.com/user-attachments/assets/c5ddc918-b78e-44e5-a407-0e9edd13214c" />
