### PR TITLE
feat(bar): add volume scroll with percentage display and cpu boost toggle

### DIFF
--- a/modules/common/widgets/ResourceCard.qml
+++ b/modules/common/widgets/ResourceCard.qml
@@ -14,11 +14,23 @@ Rectangle {
     property color sublabelColor: Appearance.colors.colOnSurfaceVariant
     property int cardWidth: 150 
 
+    signal clicked()
+    property bool clickable: false
+
     width: cardWidth
     height: 96 
     radius: 16 
     
-    color: Appearance.colors.colSurfaceContainerLow
+    color: root.clickable && cardMouseArea.containsMouse ? Appearance.colors.colSurfaceContainerHigh : Appearance.colors.colSurfaceContainerLow
+
+    MouseArea {
+        id: cardMouseArea
+        anchors.fill: parent
+        enabled: root.clickable
+        hoverEnabled: root.clickable
+        cursorShape: root.clickable ? Qt.PointingHandCursor : Qt.ArrowCursor
+        onClicked: root.clicked()
+    }
 
     function usageColor(v) {
         if (v > 0.9) return Appearance.colors.colError

--- a/modules/ii/bar/Resource.qml
+++ b/modules/ii/bar/Resource.qml
@@ -1,3 +1,4 @@
+import qs.services
 import qs.modules.common
 import qs.modules.common.functions
 import qs.modules.common.widgets
@@ -7,6 +8,7 @@ import QtQuick.Layouts
 Item {
     id: root
     required property string iconName
+    property bool isCpu: iconName === "planner_review"
     required property double percentage
     property bool vertical: false
     property int warningThreshold: 100
@@ -37,6 +39,32 @@ Item {
                     iconSize: Appearance.font.pixelSize.normal
                     color: Appearance.colors.colOnSecondaryContainer
                 }
+
+                Rectangle {
+                    visible: root.isCpu && ResourceUsage.hasBoostControl
+                    anchors {
+                        top: parent.top
+                        right: parent.right
+                        topMargin: -2
+                        rightMargin: -2
+                    }
+                    width: 8
+                    height: 8
+                    radius: Appearance.rounding.full
+                    color: ResourceUsage.cpuBoostEnabled ? (Appearance.colors.colPrimary || Appearance.m3colors.m3primary) : Appearance.colors.colLayer0Border
+                    border.width: 1.5
+                    border.color: Appearance.colors.colLayer0
+                    z: 5
+
+                    MaterialSymbol {
+                        anchors.centerIn: parent
+                        text: "bolt"
+                        font.weight: Font.Black
+                        iconSize: 5
+                        color: ResourceUsage.cpuBoostEnabled ? (Appearance.colors.colOnPrimary || Appearance.m3colors.m3onPrimary) : Appearance.colors.colOnLayer1Inactive
+                        visible: ResourceUsage.cpuBoostEnabled
+                    }
+                }
             }
         }
     }
@@ -61,6 +89,32 @@ Item {
                     text: root.iconName
                     iconSize: Appearance.font.pixelSize.normal
                     color: Appearance.m3colors.m3onSecondaryContainer
+                }
+
+                Rectangle {
+                    visible: root.isCpu && ResourceUsage.hasBoostControl
+                    anchors {
+                        top: parent.top
+                        right: parent.right
+                        topMargin: -2
+                        rightMargin: -2
+                    }
+                    width: 8
+                    height: 8
+                    radius: Appearance.rounding.full
+                    color: ResourceUsage.cpuBoostEnabled ? (Appearance.colors.colPrimary || Appearance.m3colors.m3primary) : Appearance.colors.colLayer0Border
+                    border.width: 1.5
+                    border.color: Appearance.colors.colLayer0
+                    z: 5
+
+                    MaterialSymbol {
+                        anchors.centerIn: parent
+                        text: "bolt"
+                        font.weight: Font.Black
+                        iconSize: 5
+                        color: ResourceUsage.cpuBoostEnabled ? (Appearance.colors.colOnPrimary || Appearance.m3colors.m3onPrimary) : Appearance.colors.colOnLayer1Inactive
+                        visible: ResourceUsage.cpuBoostEnabled
+                    }
                 }
             }
         }
@@ -117,8 +171,19 @@ Item {
     MouseArea {
         anchors.fill: parent
         hoverEnabled: true
-        acceptedButtons: Qt.NoButton
+        acceptedButtons: (root.isCpu && ResourceUsage.hasBoostControl) ? Qt.LeftButton : Qt.NoButton
+        cursorShape: (root.isCpu && ResourceUsage.hasBoostControl) ? Qt.PointingHandCursor : Qt.ArrowCursor
         enabled: vertical ? root.visible : (resourceRowLayout.x >= 0 && root.width > 0 && root.visible)
+        onClicked: {
+            if (root.isCpu && ResourceUsage.hasBoostControl) {
+                ResourceUsage.toggleCpuBoost()
+            }
+        }
+
+        StyledToolTip {
+            visible: (root.isCpu && ResourceUsage.hasBoostControl) && parent.containsMouse
+            text: ResourceUsage.cpuBoostEnabled ? Translation.tr("CPU Turbo Boost: Enabled\nClick to disable") : Translation.tr("CPU Turbo Boost: Disabled\nClick to enable")
+        }
     }
 
     Behavior on implicitWidth {

--- a/modules/ii/bar/ResourcesPopup.qml
+++ b/modules/ii/bar/ResourcesPopup.qml
@@ -30,10 +30,14 @@ StyledPopup {
                 iconText: "planner_review"
                 iconShape: MaterialShape.Shape.Gem
                 value: ResourceUsage.cpuUsage
-                sublabel: `${Math.round(ResourceUsage.cpuTemp)}°C`
+                sublabel: ResourceUsage.hasBoostControl
+                    ? `${Math.round(ResourceUsage.cpuTemp)}°C • Boost ${ResourceUsage.cpuBoostEnabled ? "ON" : "OFF"}`
+                    : `${Math.round(ResourceUsage.cpuTemp)}°C`
                 sublabelColor: ResourceUsage.cpuTemp > 80 ? Appearance.colors.colError
                     : ResourceUsage.cpuTemp > 60 ? Appearance.m3colors.m3tertiary
-                    : Appearance.colors.colOnLayer1
+                    : (ResourceUsage.hasBoostControl && ResourceUsage.cpuBoostEnabled ? Appearance.colors.colPrimary : Appearance.colors.colOnLayer1)
+                clickable: ResourceUsage.hasBoostControl
+                onClicked: ResourceUsage.toggleCpuBoost()
             }
         }
 

--- a/modules/ii/bar/SystemIcons.qml
+++ b/modules/ii/bar/SystemIcons.qml
@@ -33,10 +33,81 @@ Item {
 
         Revealer {
             reveal: true
-            MaterialSymbol {
-                text: Audio.sink?.audio?.muted ? "volume_off" : "volume_up"
-                iconSize: Appearance.font.pixelSize.larger
-                color: root.isMaterial ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer1
+            Item {
+                id: volumeItem
+                implicitWidth: root.vertical ? volumeColLayout.implicitWidth : volumeRowLayout.implicitWidth
+                implicitHeight: root.vertical ? volumeColLayout.implicitHeight : volumeRowLayout.implicitHeight
+
+                RowLayout {
+                    id: volumeRowLayout
+                    visible: !root.vertical
+                    anchors.centerIn: parent
+                    spacing: 3
+
+                    MaterialSymbol {
+                        Layout.alignment: Qt.AlignVCenter
+                        text: {
+                            if (Audio.sink?.audio?.muted) return "volume_off";
+                            const vol = Audio.sink?.audio?.volume ?? 0;
+                            if (vol <= 0) return "volume_mute";
+                            if (vol < 0.5) return "volume_down";
+                            return "volume_up";
+                        }
+                        iconSize: Appearance.font.pixelSize.larger
+                        color: root.isMaterial ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer1
+                    }
+
+                    StyledText {
+                        Layout.alignment: Qt.AlignVCenter
+                        font.pixelSize: Appearance.font.pixelSize.small
+                        font.features: { "tnum": 1 }
+                        color: root.isMaterial ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer1
+                        text: `${Math.round((Audio.sink?.audio?.volume ?? 0) * 100)}`
+                    }
+                }
+
+                ColumnLayout {
+                    id: volumeColLayout
+                    visible: root.vertical
+                    anchors.centerIn: parent
+                    spacing: 1
+
+                    MaterialSymbol {
+                        Layout.alignment: Qt.AlignHCenter
+                        text: {
+                            if (Audio.sink?.audio?.muted) return "volume_off";
+                            const vol = Audio.sink?.audio?.volume ?? 0;
+                            if (vol <= 0) return "volume_mute";
+                            if (vol < 0.5) return "volume_down";
+                            return "volume_up";
+                        }
+                        iconSize: Appearance.font.pixelSize.larger
+                        color: root.isMaterial ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer1
+                    }
+
+                    StyledText {
+                        Layout.alignment: Qt.AlignHCenter
+                        font.pixelSize: Appearance.font.pixelSize.smallest
+                        font.features: { "tnum": 1 }
+                        color: root.isMaterial ? Appearance.colors.colOnPrimary : Appearance.colors.colOnLayer1
+                        text: `${Math.round((Audio.sink?.audio?.volume ?? 0) * 100)}`
+                    }
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.LeftButton
+                    onWheel: wheel => {
+                        if (wheel.angleDelta.y > 0) {
+                            Audio.incrementVolume();
+                        } else if (wheel.angleDelta.y < 0) {
+                            Audio.decrementVolume();
+                        }
+                    }
+                    onPressed: mouse => {
+                        GlobalStates.sidebarRightOpen = !GlobalStates.sidebarRightOpen;
+                    }
+                }
             }
         }
         Revealer {

--- a/modules/ii/screenCorners/ScreenCorners.qml
+++ b/modules/ii/screenCorners/ScreenCorners.qml
@@ -102,9 +102,7 @@ Scope {
                         if (cornerWidget.isLeft)
                             Brightness.decreaseBrightness()
                         else {
-                            const currentVolume = Audio.value;
-                            const step = currentVolume < 0.1 ? 0.01 : 0.02 || 0.2;
-                            Audio.sink.audio.volume -= step;
+                            Audio.decrementVolume();
                         }
                     }
                     onScrollUp: {
@@ -113,9 +111,7 @@ Scope {
                         if (cornerWidget.isLeft)
                             Brightness.increaseBrightness()
                         else {
-                            const currentVolume = Audio.value;
-                            const step = currentVolume < 0.1 ? 0.01 : 0.02 || 0.2;
-                            Audio.sink.audio.volume = Math.min(1, Audio.sink.audio.volume + step);
+                            Audio.incrementVolume();
                         }
                     }
                     onMovedAway: {

--- a/services/Audio.qml
+++ b/services/Audio.qml
@@ -50,23 +50,27 @@ Singleton {
 
     // Controls
     function toggleMute() {
-        Audio.sink.audio.muted = !Audio.sink.audio.muted
+        if (!Audio.sink?.audio) return;
+        Audio.sink.audio.muted = !Audio.sink.audio.muted;
     }
 
     function toggleMicMute() {
-        Audio.source.audio.muted = !Audio.source.audio.muted
+        if (!Audio.source?.audio) return;
+        Audio.source.audio.muted = !Audio.source.audio.muted;
     }
 
-    function incrementVolume() {
-        const currentVolume = Audio.value;
-        const step = currentVolume < 0.1 ? 0.01 : 0.02 || 0.2;
-        Audio.sink.audio.volume = Math.min(1, Audio.sink.audio.volume + step);
+    function incrementVolume(step = 0.02) {
+        if (!Audio.sink?.audio) return;
+        const currentVolPercent = Math.round((Audio.sink.audio.volume ?? 0) * 100);
+        const stepPercent = Math.round(step * 100);
+        Audio.sink.audio.volume = Math.min(1.0, (currentVolPercent + stepPercent) / 100);
     }
     
-    function decrementVolume() {
-        const currentVolume = Audio.value;
-        const step = currentVolume < 0.1 ? 0.01 : 0.02 || 0.2;
-        Audio.sink.audio.volume -= step;
+    function decrementVolume(step = 0.02) {
+        if (!Audio.sink?.audio) return;
+        const currentVolPercent = Math.round((Audio.sink.audio.volume ?? 0) * 100);
+        const stepPercent = Math.round(step * 100);
+        Audio.sink.audio.volume = Math.max(0.0, (currentVolPercent - stepPercent) / 100);
     }
 
     function setDefaultSink(node) {

--- a/services/ResourceUsage.qml
+++ b/services/ResourceUsage.qml
@@ -38,7 +38,61 @@ Singleton {
     property real diskFree: 0
     property real diskUsedPercentage: diskTotal > 0 ? diskUsed / diskTotal : 0
     property list<real> diskUsageHistory: []
-    property string maxAvailableDiskString: kbToGbString(diskTotal)
+    property string activeBoostPath: ""
+    property string activeBoostType: ""
+    property bool hasBoostControl: false
+    property bool cpuBoostEnabled: true
+
+    function syncBoostState() {
+        if (!root.hasBoostControl || !fileBoost.loaded) return;
+        const val = fileBoost.text().trim();
+        if (val.length === 0) return;
+        if (root.activeBoostType === "intel_no_turbo") {
+            root.cpuBoostEnabled = (val === "0");
+        } else {
+            root.cpuBoostEnabled = (val === "1");
+        }
+    }
+
+    function toggleCpuBoost() {
+        if (!root.hasBoostControl || toggleCpuBoostProc.running) return;
+        toggleCpuBoostProc.running = true;
+    }
+
+    Process {
+        id: boostProbeProc
+        running: true
+        command: ["bash", "-c", "if [ -f /sys/devices/system/cpu/intel_pstate/no_turbo ]; then echo 'intel_no_turbo /sys/devices/system/cpu/intel_pstate/no_turbo'; elif [ -f /sys/devices/system/cpu/cpufreq/boost ]; then echo 'cpufreq_boost /sys/devices/system/cpu/cpufreq/boost'; elif [ -f /sys/devices/system/cpu/amd_pstate/cpupower/boost ]; then echo 'amd_boost /sys/devices/system/cpu/amd_pstate/cpupower/boost'; fi"]
+        stdout: StdioCollector {
+            onStreamFinished: {
+                const parts = text.trim().split(" ");
+                if (parts.length >= 2 && parts[1].length > 0) {
+                    root.activeBoostType = parts[0];
+                    root.activeBoostPath = parts[1];
+                    root.hasBoostControl = true;
+                    fileBoost.reload();
+                } else {
+                    root.hasBoostControl = false;
+                }
+            }
+        }
+    }
+
+    Process {
+        id: toggleCpuBoostProc
+        command: {
+            if (!root.hasBoostControl) return ["true"];
+            const targetVal = root.activeBoostType === "intel_no_turbo"
+                ? (root.cpuBoostEnabled ? "1" : "0")
+                : (root.cpuBoostEnabled ? "0" : "1");
+            return ["pkexec", "bash", "-c", `echo ${targetVal} > "${root.activeBoostPath}"`];
+        }
+        onExited: {
+            if (fileBoost.path.length > 0) {
+                fileBoost.reload();
+            }
+        }
+    }
 
     Process {
         id: tempProc
@@ -111,6 +165,9 @@ Singleton {
         onTriggered: {
             fileMeminfo.reload()
             fileStat.reload()
+            if (root.hasBoostControl && root.activeBoostPath.length > 0) {
+                fileBoost.reload()
+            }
 
             const textMeminfo = fileMeminfo.text()
             memoryTotal = Number(textMeminfo.match(/MemTotal: *(\d+)/)?.[1] ?? 1)
@@ -139,6 +196,11 @@ Singleton {
 
     FileView { id: fileMeminfo; path: "/proc/meminfo" }
     FileView { id: fileStat;    path: "/proc/stat" }
+    FileView {
+        id: fileBoost
+        path: root.activeBoostPath
+        onLoaded: root.syncBoostState()
+    }
 
     Process {
         id: findCpuMaxFreqProc


### PR DESCRIPTION
- SystemIcons: display volume percentage next to volume icon with dynamic states (off/mute/down/up)
- SystemIcons: add mouse wheel scroll handler to easily adjust volume from the bar
- Audio: implement precision rounding in increment/decrement volume methods to prevent floating-point drift
- Audio: add null-safety guards in toggleMute and toggleMicMute to prevent TypeErrors when sinks disconnect
- ScreenCorners: reuse Audio increment/decrement helpers instead of duplicating volume math
- ResourceUsage: probe Linux kernel CPU boost controls across Intel (no_turbo) and AMD (boost)
- ResourceUsage: add pkexec toggle command and state sync via FileView
- Resource: add visual lightning badge on CPU usage bar item when boost is enabled, with click-to-toggle tooltip
- ResourcesPopup: show CPU boost status and allow toggling from CPU resource card
- ResourceCard: add clickable property with hover effects and pointer cursor