### PR TITLE
feat(wallpapers): add video wallpaper support and sync centered shapes

### DIFF
--- a/GlobalStates.qml
+++ b/GlobalStates.qml
@@ -50,11 +50,11 @@ Singleton {
 
     // Shared by desktop (Background) and lock screen (LockSurface) scroll-to-cycle
     readonly property var centeredShapeOptions: [
-        "Circle", "Square", "Slanted", "Arch", "Arrow", "SemiCircle", "Oval", "Pill",
+        "Circle", "Square", "Slanted", "Arch", "Fan", "Arrow", "SemiCircle", "Oval", "Pill",
         "Triangle", "Diamond", "ClamShell", "Pentagon", "Gem", "Sunny", "VerySunny",
         "Cookie4Sided", "Cookie6Sided", "Cookie7Sided", "Cookie9Sided", "Cookie12Sided",
-        "Ghostish", "Clover4Leaf", "Clover8Leaf", "Burst", "SoftBurst", "Flower",
-        "Puffy", "PuffyDiamond", "PixelCircle", "Bun", "Heart"
+        "Ghostish", "Clover4Leaf", "Clover8Leaf", "Burst", "SoftBurst", "Boom", "SoftBoom", "Flower",
+        "Puffy", "PuffyDiamond", "PixelCircle", "PixelTriangle", "Bun", "Heart"
     ]
     function cycleCenteredWallpaperShape(direction) {
         const opts = root.centeredShapeOptions

--- a/modules/common/widgets/ThumbnailImage.qml
+++ b/modules/common/widgets/ThumbnailImage.qml
@@ -42,8 +42,10 @@ StyledImage {
         id: thumbnailGeneration
         command: {
             const maxSize = Images.thumbnailSizes[root.thumbnailSizeName];
+            const cleanSource = FileUtils.trimFileProtocol(root.sourcePath);
+            const cleanThumb = FileUtils.trimFileProtocol(root.thumbnailPath);
             return ["bash", "-c", 
-                `[ -f '${FileUtils.trimFileProtocol(root.thumbnailPath)}' ] && exit 0 || { magick '${root.sourcePath}' -resize ${maxSize}x${maxSize} '${FileUtils.trimFileProtocol(root.thumbnailPath)}' && exit 1; }`
+                `[ -f '${cleanThumb}' ] && exit 0 || { case '${cleanSource.toLowerCase()}' in *.mp4|*.webm|*.mkv|*.avi|*.mov) ffmpeg -y -i '${cleanSource}' -vframes 1 -update 1 -vf 'scale=${maxSize}:${maxSize}:force_original_aspect_ratio=decrease' '${cleanThumb}' 2>/dev/null ;; *) magick '${cleanSource}' -resize ${maxSize}x${maxSize} '${cleanThumb}' ;; esac && exit 1; }`
             ]
         }
         onExited: (exitCode, exitStatus) => {

--- a/modules/ii/wallpaperSelector/WallpaperSelectorContent.qml
+++ b/modules/ii/wallpaperSelector/WallpaperSelectorContent.qml
@@ -25,6 +25,7 @@ MouseArea {
     property var quickDirs: [
         { icon: "home",       name: "Home   ",       path: `${Directories.home}`,                alwaysVisible: Config.options.wallpaperSelector.showHomePath },
         { icon: "wallpaper",  name: "Wallpapers   ", path: `${Directories.pictures}/Wallpapers`, alwaysVisible: true },
+        { icon: "movie",      name: "Videos   ",     path: `${Directories.videos}`,              alwaysVisible: true },
         { icon: "imagesmode", name: "Homework   ",   path: `${Directories.pictures}/homework`,   alwaysVisible: Config.options.policies.weeb },
         { icon: "casino",     name: "Random   ",     path: `${Directories.pictures}/Random`,     alwaysVisible: true },
         { 

--- a/scripts/colors/switchwall.sh
+++ b/scripts/colors/switchwall.sh
@@ -106,7 +106,7 @@ CUSTOM_DIR="$XDG_CONFIG_HOME/hypr/custom"
 RESTORE_SCRIPT_DIR="$CUSTOM_DIR/scripts"
 RESTORE_SCRIPT="$RESTORE_SCRIPT_DIR/__restore_video_wallpaper.sh"
 THUMBNAIL_DIR="$RESTORE_SCRIPT_DIR/mpvpaper_thumbnails"
-VIDEO_OPTS="no-audio loop hwdec=auto scale=bilinear interpolation=no video-sync=display-resample panscan=1.0 video-scale-x=1.0 video-scale-y=1.0 video-align-x=0.5 video-align-y=0.5 load-scripts=no"
+VIDEO_OPTS="no-audio loop hwdec=auto scale=bilinear interpolation=no video-sync=audio panscan=1.0 video-scale-x=1.0 video-scale-y=1.0 video-align-x=0.0 video-align-y=0.0 load-scripts=no"
 
 is_video() {
     local extension="${1##*.}"
@@ -127,7 +127,7 @@ create_restore_script() {
 pkill -f -9 mpvpaper
 
 for monitor in \$(hyprctl monitors -j | jq -r '.[] | .name'); do
-    mpvpaper -o "$VIDEO_OPTS" "\$monitor" "$video_path" &
+    setsid -f mpvpaper -o "$VIDEO_OPTS" "\$monitor" "$video_path" >/dev/null 2>&1
     sleep 0.1
 done
 EOF
@@ -234,7 +234,7 @@ switch() {
                 local video_path="$imgpath"
                 monitors=$(hyprctl monitors -j | jq -r '.[] | .name')
                 for monitor in $monitors; do
-                    mpvpaper -o "$VIDEO_OPTS" "$monitor" "$video_path" &
+                    setsid -f mpvpaper -o "$VIDEO_OPTS" "$monitor" "$video_path" >/dev/null 2>&1
                     sleep 0.1
                 done
             fi

--- a/scripts/thumbnails/generate-thumbnails-magick.sh
+++ b/scripts/thumbnails/generate-thumbnails-magick.sh
@@ -47,16 +47,9 @@ generate_thumbnail() {
     local src="$1"
     local abs_path
     abs_path="$(realpath "$src")"
-    # Skip files with multiple frames (GIFs, videos, etc.)
-    case "${abs_path,,}" in
-        *.gif|*.mp4|*.webm|*.mkv|*.avi|*.mov)
-            return
-            ;;
-    esac
     local encoded_path
     encoded_path="$(urlencode "$abs_path")"
-    local uri
-    uri="file://$encoded_path"
+    local uri="file://$encoded_path"
     local hash
     hash="$(md5 "$uri")"
     local out="$CACHE_DIR/$hash.png"
@@ -64,6 +57,17 @@ generate_thumbnail() {
     if [ -f "$out" ]; then
         return
     fi
+    case "${abs_path,,}" in
+        *.gif)
+            return
+            ;;
+        *.mp4|*.webm|*.mkv|*.avi|*.mov)
+            if command -v ffmpeg &>/dev/null; then
+                ffmpeg -y -i "$abs_path" -vframes 1 -update 1 -vf "scale=${THUMBNAIL_SIZE}:${THUMBNAIL_SIZE}:force_original_aspect_ratio=decrease" "$out" 2>/dev/null
+            fi
+            return
+            ;;
+    esac
     magick "$abs_path" -resize "${THUMBNAIL_SIZE}x${THUMBNAIL_SIZE}" "$out"
 }
 
@@ -91,8 +95,6 @@ while [[ $# -gt 0 ]]; do
             usage
             ;;
     esac
-    # Only one mode allowed
-    [[ -n "$MODE" ]] && break
 done
 
 THUMBNAIL_SIZE="$(get_thumbnail_size "$SIZE_NAME")"

--- a/scripts/thumbnails/thumbgen.py
+++ b/scripts/thumbnails/thumbgen.py
@@ -76,9 +76,9 @@ def thumbnail_folder(*, dir_path: Path, workers: int, only_images: bool, recursi
 
 
 def get_all_images(*, all_files: List[Path]) -> List[Path]:
-    img_suffixes = [".jpg", ".jpeg", ".png", ".gif"]
-    all_images = [fpath for fpath in all_files if fpath.suffix in img_suffixes]
-    print("Found {} images".format(len(all_images)))
+    img_suffixes = [".jpg", ".jpeg", ".png", ".gif", ".webp", ".avif", ".bmp", ".mp4", ".webm", ".mkv", ".avi", ".mov"]
+    all_images = [fpath for fpath in all_files if fpath.suffix.lower() in img_suffixes]
+    print("Found {} media files".format(len(all_images)))
     return all_images
 
 

--- a/services/Wallpapers.qml
+++ b/services/Wallpapers.qml
@@ -32,8 +32,8 @@ Singleton {
     property var orderMap: ({})
     property bool orderLoaded: false
     property string searchQuery: ""
-    readonly property list<string> extensions: [ // TODO: add videos
-        "jpg", "jpeg", "png", "webp", "avif", "bmp", "svg"
+    readonly property list<string> extensions: [
+        "jpg", "jpeg", "png", "webp", "avif", "bmp", "svg", "mp4", "webm", "mkv", "avi", "mov"
     ]
     property list<string> wallpapers: [] // List of absolute file paths (without file://)
     readonly property bool thumbnailGenerationRunning: thumbgenProc.running


### PR DESCRIPTION
- Wallpapers: add video extensions (mp4, webm, mkv, avi, mov) resolving upstream TODO
- switchwall.sh: detach mpvpaper via setsid with redirected output to avoid blocking and prevent premature process termination
- switchwall.sh: optimize VIDEO_OPTS for smooth video wallpaper rendering and alignment
- generate-thumbnails-magick.sh: extract video thumbnails using single-frame ffmpeg capture
- generate-thumbnails-magick.sh: fix option parsing loop early break bug
- thumbgen.py: scan and discover video and modern image formats (webp, avif, bmp, mp4, webm, mkv, avi, mov)
- ThumbnailImage: add ffmpeg first-frame thumbnail generation fallback for videos with sanitized paths
- WallpaperSelectorContent: add quick-navigation shortcut for the Videos directory
- GlobalStates: synchronize centeredShapeOptions with Background.qml (add Fan, Boom, SoftBoom, PixelTriangle)