### PR TITLE
feat(settings): add hdr and color management options

### DIFF
--- a/modules/common/models/hyprland/MonitorConfigOption.qml
+++ b/modules/common/models/hyprland/MonitorConfigOption.qml
@@ -1,14 +1,22 @@
 pragma ComponentBehavior: Bound
 import QtQml
 import QtQuick
+import Quickshell
 import Quickshell.Io
 import qs.services
+import qs.modules.common
+import qs.modules.common.functions
 import "../"
 
 NestableObject {
     id: root
 
     property var monitors: []
+    property var _pendingChanges: ({})
+
+    readonly property string configuratorScriptPath: Quickshell.shellPath("scripts/hyprland/monitor_configurator.py")
+    readonly property string capsScriptPath: Quickshell.shellPath("scripts/hyprland/monitor_caps.py")
+    readonly property string monitorsLuaPath: FileUtils.trimFileProtocol(`${Directories.config}/hypr/monitors.lua`)
 
     Component.onCompleted: fetchProc.running = true
 
@@ -16,38 +24,84 @@ NestableObject {
         let m = root.monitors.slice()
         m[index] = Object.assign({}, m[index], changes)
         root.monitors = m
+
+        let pending = Object.assign({}, root._pendingChanges)
+        pending[index] = Object.assign({}, pending[index] || {}, changes)
+        root._pendingChanges = pending
     }
 
-    function _buildLuaLine(m) {
-        if (m.disabled)
-            return `hl.monitor({ output = "${m.name}", disabled = true })`
-
-        const pos = `${m.x}x${m.y}`
-        let line = `hl.monitor({ output = "${m.name}", mode = "${m.currentMode}", position = "${pos}", scale = ${m.scale}`
-
-        if (m.transform && m.transform !== 0)
-            line += `, transform = ${m.transform}`
-
-        line += ` })`
-        return line
+    function _mergeByName(patchByName) {
+        root.monitors = root.monitors.map(mon => {
+            const patch = patchByName[mon.name]
+            return patch ? Object.assign({}, mon, patch) : mon
+        })
     }
 
-    function save() {
-        if (root.monitors.length === 0) return
-        if (root.monitors.some(m => !m.name)) return
+    function _modeToLua(m) {
+        const parts = m.currentMode.match(/(\d+)x(\d+)@([\d.]+)Hz/)
+        return parts ? `${parts[1]}x${parts[2]}@${parseFloat(parts[3])}` : m.currentMode
+    }
 
-        const lines = root.monitors.map(m => {
-            const line = root._buildLuaLine(m)
-            console.log(`[MonitorConfig] saving line: "${line}"`)
-            return line
-        }).join("\n")
+    function _fieldsToWrite(m, changedKeys) {
+        const setPairs = {}
+        const resetKeys = []
 
-        console.log(`[MonitorConfig] full file:\n${lines}`)
+        if (changedKeys.has("disabled")) {
+            if (m.disabled) setPairs["disabled"] = "1"
+            else resetKeys.push("disabled")
+        }
+        if (changedKeys.has("x") || changedKeys.has("y")) {
+            setPairs["position"] = `${m.x}x${m.y}`
+        }
+        if (changedKeys.has("currentMode") || changedKeys.has("width") || changedKeys.has("height") || changedKeys.has("refreshRate")) {
+            setPairs["mode"] = root._modeToLua(m)
+        }
+        if (changedKeys.has("scale")) setPairs["scale"] = m.scale
+        if (changedKeys.has("transform")) {
+            if (m.transform && m.transform !== 0) setPairs["transform"] = m.transform
+            else resetKeys.push("transform")
+        }
+        if (changedKeys.has("bitdepth")) {
+            if (m.bitdepth) setPairs["bitdepth"] = m.bitdepth
+            else resetKeys.push("bitdepth")
+        }
+        if (changedKeys.has("cm")) {
+            if (m.cm && m.cm !== "auto") setPairs["cm"] = m.cm
+            else resetKeys.push("cm")
+        }
+        if (changedKeys.has("sdrBrightness")) setPairs["sdrbrightness"] = m.sdrBrightness
+        if (changedKeys.has("sdrSaturation")) setPairs["sdrsaturation"] = m.sdrSaturation
+        if (changedKeys.has("minLuminance")) setPairs["min_luminance"] = m.minLuminance
+        if (changedKeys.has("maxLuminance")) setPairs["max_luminance"] = m.maxLuminance
+        if (changedKeys.has("maxAvgLuminance")) setPairs["max_avg_luminance"] = m.maxAvgLuminance
+        if (changedKeys.has("sdrMinLuminance")) setPairs["sdr_min_luminance"] = m.sdrMinLuminance
+        if (changedKeys.has("sdrMaxLuminance")) setPairs["sdr_max_luminance"] = m.sdrMaxLuminance
+        if (changedKeys.has("vrr")) setPairs["vrr"] = m.vrr ? "1" : "0"
 
-        const escaped = lines.replace(/'/g, "'\\''")
-        saveProc.command = ["bash", "-c",
-            `printf '%s\n' '${escaped}' > ~/.config/hypr/monitors.lua`]
+        return { setPairs, resetKeys }
+    }
+
+    function save(index) {
+        const m = root.monitors[index]
+        if (!m || !m.name) return
+
+        const changed = root._pendingChanges[index]
+        if (!changed) return
+        const changedKeys = new Set(Object.keys(changed))
+        const { setPairs, resetKeys } = root._fieldsToWrite(m, changedKeys)
+
+        if (Object.keys(setPairs).length === 0 && resetKeys.length === 0) return
+
+        let args = ["python3", root.configuratorScriptPath, "--file", root.monitorsLuaPath, "--output", m.name]
+        for (const key in setPairs) args.push("--set", key, String(setPairs[key]))
+        for (const key of resetKeys) args.push("--reset", key)
+
+        saveProc.command = args
         saveProc.running = true
+
+        let pending = Object.assign({}, root._pendingChanges)
+        delete pending[index]
+        root._pendingChanges = pending
     }
 
     function applyMonitor(m) {
@@ -65,7 +119,11 @@ NestableObject {
 
     function applyAndSave(index) {
         root.applyMonitor(root.monitors[index])
-        root.save()
+        root.save(index)
+    }
+
+    function saveHdr(index) {
+        root.save(index)
     }
 
     function logicalWidth(m) {
@@ -94,10 +152,71 @@ NestableObject {
                         transform:     m.transform ?? 0,
                         disabled:      m.disabled,
                         availableModes: m.availableModes,
-                        currentMode:   `${m.width}x${m.height}@${m.refreshRate.toFixed(2)}Hz`
+                        currentMode:   `${m.width}x${m.height}@${m.refreshRate.toFixed(2)}Hz`,
+                        cm:            m.colorManagementPreset ?? "auto",
+                        sdrBrightness: m.sdrBrightness ?? 1.0,
+                        sdrSaturation: m.sdrSaturation ?? 1.0,
+                        sdrMinLuminance: m.sdrMinLuminance ?? 0,
+                        sdrMaxLuminance: m.sdrMaxLuminance ?? 0,
+                        vrr:           m.vrr ?? false,
+                        bitdepth:        null,
+                        minLuminance:    null,
+                        maxLuminance:    null,
+                        maxAvgLuminance: null,
+
+                        hdrSupported: null,
+                        maxBpc:       null,
                     }))
+                    if (root.monitors.length > 0) {
+                        capsProc.command = ["python3", root.capsScriptPath].concat(root.monitors.map(mon => mon.name))
+                        capsProc.running = true
+                        dumpProc.command = ["python3", root.configuratorScriptPath, "--file", root.monitorsLuaPath, "--dump-all"]
+                        dumpProc.running = true
+                    }
                 } catch(e) {
                     console.log("[MonitorConfig] Error parseando JSON:", e)
+                }
+            }
+        }
+    }
+
+    Process {
+        id: capsProc
+        stdout: StdioCollector {
+            onStreamFinished: {
+                try {
+                    const caps = JSON.parse(text)
+                    let patch = {}
+                    for (const name in caps) {
+                        patch[name] = { hdrSupported: caps[name].hdr, maxBpc: caps[name].maxBpc }
+                    }
+                    root._mergeByName(patch)
+                } catch(e) {
+                    console.log("[MonitorConfig] Error parsing caps JSON:", e)
+                }
+            }
+        }
+    }
+
+    Process {
+        id: dumpProc
+        stdout: StdioCollector {
+            onStreamFinished: {
+                try {
+                    const dump = JSON.parse(text)
+                    let patch = {}
+                    for (const name in dump) {
+                        const d = dump[name]
+                        patch[name] = {
+                            bitdepth:        d.bitdepth ?? null,
+                            minLuminance:    d.min_luminance ?? null,
+                            maxLuminance:    d.max_luminance ?? null,
+                            maxAvgLuminance: d.max_avg_luminance ?? null,
+                        }
+                    }
+                    root._mergeByName(patch)
+                } catch(e) {
+                    console.log("[MonitorConfig] Error parsing monitors.lua dump JSON:", e)
                 }
             }
         }

--- a/modules/ii/settings/pages/HyprlandConfig.qml
+++ b/modules/ii/settings/pages/HyprlandConfig.qml
@@ -174,7 +174,178 @@ ContentPage {
                             monitorConfig.applyAndSave(monitorCanvas.selectedIndex)
                         }
                     }
-                }        
+                }
+            }
+
+            ContentSubsection {
+                Layout.topMargin: 10
+                title: Translation.tr("HDR & Color Management")
+
+                NoticeBox {
+                    Layout.fillWidth: true
+                    visible: monitorConfig.monitors[monitorCanvas.selectedIndex]?.hdrSupported === null
+                    text: Translation.tr("Couldn't confirm this display's HDR capability from its EDID. Options are shown but may not do anything.")
+                }
+
+                NoticeBox {
+                    Layout.fillWidth: true
+                    visible: monitorConfig.monitors[monitorCanvas.selectedIndex]?.hdrSupported === false
+                    text: Translation.tr("This display's EDID does not report HDR support, enabling it below is unlikely to work correctly.")
+                }
+
+                GroupedList {
+                    ConfigSelectionArray {
+                        text: Translation.tr("Bit depth")
+                        icon: "gradient"
+                        currentValue: monitorConfig.monitors[monitorCanvas.selectedIndex]?.bitdepth
+                            ?? (monitorConfig.monitors[monitorCanvas.selectedIndex]?.maxBpc ?? 8)
+                        onSelected: newValue => {
+                            monitorConfig.updateMonitor(monitorCanvas.selectedIndex, { bitdepth: newValue })
+                            monitorConfig.saveHdr(monitorCanvas.selectedIndex)
+                        }
+                        options: (() => {
+                            const maxBpc = monitorConfig.monitors[monitorCanvas.selectedIndex]?.maxBpc ?? 8
+                            return [
+                                { displayName: "8-bit",  icon: "filter_8", value: 8  },
+                                { displayName: "10-bit", icon: "palette",   value: 10 },
+                                { displayName: "12-bit", icon: "hdr_on",   value: 12 },
+                            ].filter(o => o.value <= maxBpc)
+                        })()
+                    }
+
+                    ConfigComboBox {
+                        Layout.fillWidth: true
+                        buttonIcon: "palette"
+                        text: Translation.tr("Color management")
+                        enabled: monitorConfig.monitors[monitorCanvas.selectedIndex]?.hdrSupported !== false
+                        model: [
+                            { displayName: Translation.tr("Auto"),       icon: "auto_awesome",  value: "auto"    },
+                            { displayName: "sRGB",                       icon: "light_mode",    value: "srgb"    },
+                            { displayName: Translation.tr("Wide (P3)"),  icon: "wb_iridescent", value: "wide"    },
+                            { displayName: "HDR",                        icon: "hdr_on",        value: "hdr"     },
+                            { displayName: Translation.tr("HDR (EDID)"), icon: "hdr_auto",      value: "hdredid" },
+                        ]
+                        currentValue: monitorConfig.monitors[monitorCanvas.selectedIndex]?.cm ?? "auto"
+                        onSelected: newValue => {
+                            monitorConfig.updateMonitor(monitorCanvas.selectedIndex, { cm: newValue })
+                            monitorConfig.saveHdr(monitorCanvas.selectedIndex)
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+
+                        ConfigSpinBox {
+                            Layout.fillWidth: true
+                            enabled: monitorConfig.monitors[monitorCanvas.selectedIndex]?.cm === "hdr" || monitorConfig.monitors[monitorCanvas.selectedIndex]?.cm === "hdredid"
+                            icon: "brightness_6"
+                            text: Translation.tr("SDR brightness")
+                            value: Math.round((monitorConfig.monitors[monitorCanvas.selectedIndex]?.sdrBrightness ?? 1.0) * 100)
+                            from: 10; to: 300; stepSize: 5
+                            onValueChanged: {
+                                const newVal = value / 100.0
+                                if (newVal === (monitorConfig.monitors[monitorCanvas.selectedIndex]?.sdrBrightness ?? 1.0)) return
+                                monitorConfig.updateMonitor(monitorCanvas.selectedIndex, { sdrBrightness: newVal })
+                                monitorConfig.saveHdr(monitorCanvas.selectedIndex)
+                            }
+                        }
+
+                        ConfigSpinBox {
+                            Layout.fillWidth: true
+                            enabled: monitorConfig.monitors[monitorCanvas.selectedIndex]?.cm === "hdr" || monitorConfig.monitors[monitorCanvas.selectedIndex]?.cm === "hdredid"
+                            icon: "contrast"
+                            text: Translation.tr("SDR saturation")
+                            value: Math.round((monitorConfig.monitors[monitorCanvas.selectedIndex]?.sdrSaturation ?? 1.0) * 100)
+                            from: 10; to: 200; stepSize: 5
+                            onValueChanged: {
+                                const newVal = value / 100.0
+                                if (newVal === (monitorConfig.monitors[monitorCanvas.selectedIndex]?.sdrSaturation ?? 1.0)) return
+                                monitorConfig.updateMonitor(monitorCanvas.selectedIndex, { sdrSaturation: newVal })
+                                monitorConfig.saveHdr(monitorCanvas.selectedIndex)
+                            }
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+
+                        ConfigSpinBox {
+                            Layout.fillWidth: true
+                            icon: "wb_twilight"
+                            text: Translation.tr("SDR min (nits)")
+                            value: monitorConfig.monitors[monitorCanvas.selectedIndex]?.sdrMinLuminance ?? 0
+                            from: 0; to: 100; stepSize: 1
+                            enabled: monitorConfig.monitors[monitorCanvas.selectedIndex]?.cm === "hdr" || monitorConfig.monitors[monitorCanvas.selectedIndex]?.cm === "hdredid"
+                            onValueChanged: {
+                                if (value === (monitorConfig.monitors[monitorCanvas.selectedIndex]?.sdrMinLuminance ?? 0)) return
+                                monitorConfig.updateMonitor(monitorCanvas.selectedIndex, { sdrMinLuminance: value })
+                                monitorConfig.saveHdr(monitorCanvas.selectedIndex)
+                            }
+                        }
+
+                        ConfigSpinBox {
+                            Layout.fillWidth: true
+                            icon: "wb_sunny"
+                            text: Translation.tr("SDR max (nits)")
+                            value: monitorConfig.monitors[monitorCanvas.selectedIndex]?.sdrMaxLuminance ?? 250
+                            from: 50; to: 2000; stepSize: 10
+                            enabled: monitorConfig.monitors[monitorCanvas.selectedIndex]?.cm === "hdr" || monitorConfig.monitors[monitorCanvas.selectedIndex]?.cm === "hdredid"
+                            onValueChanged: {
+                                if (value === (monitorConfig.monitors[monitorCanvas.selectedIndex]?.sdrMaxLuminance ?? 250)) return
+                                monitorConfig.updateMonitor(monitorCanvas.selectedIndex, { sdrMaxLuminance: value })
+                                monitorConfig.saveHdr(monitorCanvas.selectedIndex)
+                            }
+                        }
+                    }
+
+                    RowLayout {
+                        Layout.fillWidth: true
+                        spacing: 8
+
+                        ConfigSpinBox {
+                            Layout.fillWidth: true
+                            icon: "nightlight"
+                            text: Translation.tr("HDR min (nits)")
+                            value: monitorConfig.monitors[monitorCanvas.selectedIndex]?.minLuminance ?? 0
+                            from: 0; to: 100; stepSize: 1
+                            enabled: monitorConfig.monitors[monitorCanvas.selectedIndex]?.cm === "hdr" || monitorConfig.monitors[monitorCanvas.selectedIndex]?.cm === "hdredid"
+                            onValueChanged: {
+                                if (value === (monitorConfig.monitors[monitorCanvas.selectedIndex]?.minLuminance ?? 0)) return
+                                monitorConfig.updateMonitor(monitorCanvas.selectedIndex, { minLuminance: value })
+                                monitorConfig.saveHdr(monitorCanvas.selectedIndex)
+                            }
+                        }
+
+                        ConfigSpinBox {
+                            Layout.fillWidth: true
+                            icon: "hdr_strong"
+                            text: Translation.tr("HDR peak (nits)")
+                            value: monitorConfig.monitors[monitorCanvas.selectedIndex]?.maxLuminance ?? 1000
+                            from: 100; to: 10000; stepSize: 50
+                            enabled: monitorConfig.monitors[monitorCanvas.selectedIndex]?.cm === "hdr" || monitorConfig.monitors[monitorCanvas.selectedIndex]?.cm === "hdredid"
+                            onValueChanged: {
+                                if (value === (monitorConfig.monitors[monitorCanvas.selectedIndex]?.maxLuminance ?? 1000)) return
+                                monitorConfig.updateMonitor(monitorCanvas.selectedIndex, { maxLuminance: value })
+                                monitorConfig.saveHdr(monitorCanvas.selectedIndex)
+                            }
+                        }
+                    }
+
+                    ConfigSpinBox {
+                        icon: "hdr_weak"
+                        text: Translation.tr("HDR max average luminance (nits)")
+                        value: monitorConfig.monitors[monitorCanvas.selectedIndex]?.maxAvgLuminance ?? 250
+                        from: 50; to: 5000; stepSize: 10
+                        enabled: monitorConfig.monitors[monitorCanvas.selectedIndex]?.cm === "hdr" || monitorConfig.monitors[monitorCanvas.selectedIndex]?.cm === "hdredid"
+                        onValueChanged: {
+                            if (value === (monitorConfig.monitors[monitorCanvas.selectedIndex]?.maxAvgLuminance ?? 250)) return
+                            monitorConfig.updateMonitor(monitorCanvas.selectedIndex, { maxAvgLuminance: value })
+                            monitorConfig.saveHdr(monitorCanvas.selectedIndex)
+                        }
+                    }
+                }
             }
         }
 

--- a/scripts/hyprland/monitor_caps.py
+++ b/scripts/hyprland/monitor_caps.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env -S /bin/sh -c "source $(eval echo $ILLOGICAL_IMPULSE_VIRTUAL_ENV)/bin/activate&&exec python -E \"$0\" \"$@\""
+import argparse
+import glob
+import json
+import os
+
+# EDID byte 20, bits 6-4: supported color bit depth on digital displays.
+BPC_CODES = {1: 6, 2: 8, 3: 10, 4: 12, 5: 14, 6: 16}
+
+# CTA-861 extended data block tags.
+EXT_TAG_HDR_STATIC_METADATA = 0x06
+EXT_TAG_HDR_DYNAMIC_METADATA = 0x14
+
+UNKNOWN_CAPS = {"digital": None, "maxBpc": None, "hdr": None, "hdrDynamic": None}
+
+
+def find_edid_path(output_name):
+    # st_size is always 0 for this sysfs attribute, so we can only check hat it exists. An empty read means disconnected.
+    matches = glob.glob(f"/sys/class/drm/card*-{output_name}/edid")
+    return matches[0] if matches else None
+
+
+def parse_edid(data):
+    caps = {"digital": False, "maxBpc": None, "hdr": False, "hdrDynamic": False}
+
+    if len(data) < 128:
+        return caps
+
+    b20 = data[20]
+    caps["digital"] = bool(b20 & 0x80)
+    if caps["digital"]:
+        bpc_code = (b20 >> 4) & 0x7
+        caps["maxBpc"] = BPC_CODES.get(bpc_code)
+
+    n_ext = data[126]
+    for i in range(n_ext):
+        start = 128 + 128 * i
+        ext = data[start:start + 128]
+        if len(ext) < 5 or ext[0] != 0x02:
+            continue  # not a CTA-861 extension block
+
+        dtd_offset = ext[2]
+        pos = 4
+        while pos < dtd_offset and pos < len(ext):
+            header = ext[pos]
+            tag = header >> 5
+            length = header & 0x1F
+            if tag == 7 and length >= 1 and pos + 1 < len(ext):
+                ext_tag = ext[pos + 1]
+                if ext_tag == EXT_TAG_HDR_STATIC_METADATA:
+                    caps["hdr"] = True
+                elif ext_tag == EXT_TAG_HDR_DYNAMIC_METADATA:
+                    caps["hdrDynamic"] = True
+            pos += length + 1
+
+    return caps
+
+
+def get_caps(output_name):
+    path = find_edid_path(output_name)
+    if not path:
+        return {**UNKNOWN_CAPS, "source": "no-edid"}
+    try:
+        with open(path, "rb") as f:
+            data = f.read()
+    except OSError:
+        return {**UNKNOWN_CAPS, "source": "read-error"}
+
+    if not data:
+        return {**UNKNOWN_CAPS, "source": "empty-edid"}
+
+    caps = parse_edid(data)
+    caps["source"] = path
+    return caps
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("outputs", nargs="+", help="Monitor output names, e.g. DP-1 HDMI-A-1")
+    args = p.parse_args()
+
+    print(json.dumps({name: get_caps(name) for name in args.outputs}))

--- a/scripts/hyprland/monitor_configurator.py
+++ b/scripts/hyprland/monitor_configurator.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env -S /bin/sh -c "source $(eval echo $ILLOGICAL_IMPULSE_VIRTUAL_ENV)/bin/activate&&exec python -E \"$0\" \"$@\""
+import argparse
+import json
+import os
+import re
+import tempfile
+
+STRING_KEYS = {"output", "mode", "position", "cm", "mirror"}
+BOOL_KEYS = {"disabled"}
+FIELD_RE = re.compile(r'^(\s*)([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*,?\s*(--.*)?$')
+OUTPUT_RE = re.compile(r'output\s*=\s*"([^"]*)"')
+
+
+def to_lua_value(key, value):
+    if key in STRING_KEYS:
+        return f'"{value}"'
+    if key in BOOL_KEYS:
+        return "false" if str(value) in ("0", "false", "False") else "true"
+    try:
+        return str(int(value))
+    except ValueError:
+        pass
+    try:
+        return str(float(value))
+    except ValueError:
+        pass
+    return f'"{value}"'
+
+
+def parse_lua_value(raw):
+    raw = raw.strip()
+    if raw in ("true", "false"):
+        return raw == "true"
+    m = re.match(r'^"(.*)"$', raw)
+    if m:
+        return m.group(1)
+    try:
+        return int(raw)
+    except ValueError:
+        pass
+    try:
+        return float(raw)
+    except ValueError:
+        pass
+    return raw
+
+
+def write_atomic(path, content):
+    dir_name = os.path.dirname(os.path.abspath(path))
+    os.makedirs(dir_name, exist_ok=True)
+    tmp_path = None
+    try:
+        with tempfile.NamedTemporaryFile(mode="w", dir=dir_name, delete=False) as f:
+            f.write(content)
+            tmp_path = f.name
+        if os.path.exists(path):
+            os.chmod(tmp_path, os.stat(path).st_mode)
+        os.replace(tmp_path, path)
+    except Exception as e:
+        if tmp_path and os.path.exists(tmp_path):
+            os.remove(tmp_path)
+        raise e
+
+
+def split_blocks(lines):
+    # Tracks paren/brace balance to find each hl.monitor({ ... }) call without needing a real Lua parser.
+    segments = []
+    in_block = False
+    balance = 0
+    block_lines = []
+
+    for line in lines:
+        if not in_block:
+            if re.search(r'hl\.monitor\s*\(', line):
+                in_block = True
+                balance = 0
+                block_lines = []
+            else:
+                segments.append(('line', line))
+                continue
+
+        block_lines.append(line)
+        balance += line.count('(') + line.count('{') - line.count(')') - line.count('}')
+        if balance <= 0:
+            joined = "".join(block_lines)
+            m = OUTPUT_RE.search(joined)
+            segments.append(('block', m.group(1) if m else None, block_lines))
+            in_block = False
+
+    if in_block:
+        # Malformed/unterminated block - keep as plain lines instead of dropping content.
+        segments.extend(('line', l) for l in block_lines)
+
+    return segments
+
+
+def rebuild_field_line(m, key, value):
+    indent, comment = m.group(1), m.group(4)
+    line = f"{indent}{key} = {value},"
+    if comment:
+        line += f" {comment}"
+    return line + "\n"
+
+
+def edit_block_lines(block_lines, set_dict, reset_keys):
+    header = block_lines[0]
+    footer = block_lines[-1]
+    body = block_lines[1:-1]
+
+    default_indent = "    "
+    for line in body:
+        m = FIELD_RE.match(line)
+        if m and m.group(1):
+            default_indent = m.group(1)
+            break
+
+    new_body = []
+    found = set()
+    for line in body:
+        if line.strip().startswith('--'):
+            new_body.append(line)
+            continue
+        m = FIELD_RE.match(line)
+        if not m:
+            new_body.append(line)
+            continue
+
+        key = m.group(2)
+        if key in reset_keys:
+            print(f"Removed: {key}")
+            continue
+        if key in set_dict:
+            new_line = rebuild_field_line(m, key, to_lua_value(key, set_dict[key]))
+            found.add(key)
+            print(f"Updated: {new_line.strip()}")
+        else:
+            # Force a trailing comma even on untouched lines so that we can safely append new lines later.
+            new_line = rebuild_field_line(m, key, m.group(3))
+        new_body.append(new_line)
+
+    for key, value in set_dict.items():
+        if key not in found:
+            new_line = f"{default_indent}{key} = {to_lua_value(key, value)},\n"
+            new_body.append(new_line)
+            print(f"Added:   {new_line.strip()}")
+
+    return [header] + new_body + [footer]
+
+
+def build_new_block(output, set_dict):
+    lines = ["hl.monitor({\n", f'    output = "{output}",\n']
+    for key, value in set_dict.items():
+        if key == "output":
+            continue
+        line = f"    {key} = {to_lua_value(key, value)},\n"
+        lines.append(line)
+        print(f"Added:   {line.strip()}")
+    lines.append("})\n")
+    return lines
+
+
+def edit_lua(file_path, output, set_pairs, reset_keys):
+    try:
+        with open(file_path) as f:
+            lines = f.readlines()
+    except FileNotFoundError:
+        lines = []
+
+    set_dict = dict(set_pairs)
+    reset_set = set(reset_keys)
+    segments = split_blocks(lines)
+
+    target_idx = None
+    for i, seg in enumerate(segments):
+        if seg[0] == 'block' and seg[1] == output:
+            target_idx = i
+            break
+
+    if target_idx is not None:
+        _, _, block_lines = segments[target_idx]
+        new_block_lines = edit_block_lines(block_lines, set_dict, reset_set)
+        segments[target_idx] = ('block', output, new_block_lines)
+    elif reset_set and not set_dict:
+        print(f"No existing block for output '{output}', nothing to reset.")
+    else:
+        full_set = dict(set_dict)
+        full_set.setdefault("output", output)
+        new_block_lines = build_new_block(output, full_set)
+        if segments and not (segments[-1][0] == 'line' and segments[-1][1].strip() == ""):
+            segments.append(('line', "\n"))
+        segments.append(('block', output, new_block_lines))
+
+    out_lines = []
+    for seg in segments:
+        if seg[0] == 'line':
+            out_lines.append(seg[1])
+        else:
+            out_lines.extend(seg[2])
+
+    write_atomic(file_path, "".join(out_lines))
+
+
+def extract_fields(block_lines):
+    result = {}
+    for line in block_lines[1:-1]:
+        if line.strip().startswith('--'):
+            continue
+        m = FIELD_RE.match(line)
+        if m:
+            result[m.group(2)] = parse_lua_value(m.group(3))
+    return result
+
+
+def read_segments(file_path):
+    try:
+        with open(file_path) as f:
+            lines = f.readlines()
+    except FileNotFoundError:
+        return []
+    return split_blocks(lines)
+
+
+def dump_block(file_path, output):
+    for seg in read_segments(file_path):
+        if seg[0] == 'block' and seg[1] == output:
+            print(json.dumps(extract_fields(seg[2])))
+            return
+    print(json.dumps({}))
+
+
+def dump_all(file_path):
+    result = {}
+    for seg in read_segments(file_path):
+        if seg[0] == 'block' and seg[1]:
+            result[seg[1]] = extract_fields(seg[2])
+    print(json.dumps(result))
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--file", default="~/.config/hypr/monitors.lua")
+    p.add_argument("--output", help="Monitor output name, e.g. DP-1 (required for --set/--reset/--dump)")
+    p.add_argument("--set", nargs=2, action="append", metavar=("KEY", "VALUE"))
+    p.add_argument("--reset", action="append", metavar="KEY")
+    p.add_argument("--dump", action="store_true", help="Print this output's current fields as JSON instead of writing")
+    p.add_argument("--dump-all", action="store_true", help="Print every output's current fields as JSON, keyed by output name")
+    args = p.parse_args()
+
+    file_path = os.path.expanduser(args.file)
+
+    if args.dump_all:
+        dump_all(file_path)
+    elif args.dump:
+        if not args.output:
+            p.error("--dump requires --output")
+        dump_block(file_path, args.output)
+    else:
+        if not args.output:
+            p.error("--set/--reset require --output")
+        raw_sets = args.set or []
+        reset_keys = args.reset or []
+        set_pairs = []
+        for k, v in raw_sets:
+            if v == "[[EMPTY]]":
+                reset_keys.append(k)
+            else:
+                set_pairs.append((k, v))
+
+        if set_pairs or reset_keys:
+            edit_lua(file_path, args.output, set_pairs, reset_keys)
+        else:
+            print("Error: specify --set, --reset, --dump, or --dump-all")


### PR DESCRIPTION
# Add HDR and color management support for monitors

## What's new

Adds HDR/color management controls to the Hyprland settings page, partially gated by what the monitor's EDID actually reports it can do, and also no longer overwrites unchanged values in `monitors.lua`.

## Added files

### `scripts/hyprland/monitor_caps.py`
Reads a monitor's EDID straight from `/sys/class/drm/` and figures out two things: the max color bit depth it supports, and whether it has an HDR static metadata block at all. 

### `scripts/hyprland/monitor_configurator.py`
Reads and writes `monitors.lua` per monitor, editing only the specific fields that changed instead of rewriting the whole file. It finds each `hl.monitor({ ... })` block, and if a field's already there it updates just that line, otherwise it appends the new field. Everything else in the file, including your own comments and any settings the UI doesn't know about, is left completely untouched. Also supports dumping a monitor's current config back out as JSON, which the settings page uses to show values that Hyprland doesn't expose live (like the EDID luminance overrides).

## Changed files

### `modules/common/models/hyprland/MonitorConfigOption.qml`
This used to fully regenerate `monitors.lua` from scratch on every change, which meant any manual tweak you'd made to that file would get silently deleted the next time you touched a slider in Settings. Now it only ever asks `monitor_configurator.py` to change the specific field that was actually edited. It also now fetches HDR capability and extra monitor fields on load.
### `modules/ii/settings/pages/HyprlandConfig.qml`
New "HDR & Color Management" section under the Displays page. Lets you set bit depth, color management mode (auto, sRGB, wide gamut, HDR, HDR with EDID primaries), SDR brightness and saturation, and the HDR/SDR luminance values. Bit depth options are limited to what the display actually supports, and HDR options get disabled if the EDID doesn't advertise HDR support.

## End result

You can now turn on and tune HDR for a monitor entirely from the Settings app, and the settings page won't offer you options your hardware can't actually do (Unless the monitor is lying to you, lol). Editing any monitor setting only touches that one setting in `monitors.lua`, so anything else you've configured by hand stays exactly as you left it.

The hdredid looks the best on my G9 by far, much more contrast than the others since it uses actual values advertised by the monitor meaning it actually becomes pretty damn accurate color-wise. 

# Showcase
<img width="990" height="690" alt="image" src="https://github.com/user-attachments/assets/d7331534-3b13-4311-965d-693815c5be4f" />
