### PR TITLE
fix(notifications): guard against null timer in cancelTimeout

### DIFF
--- a/services/Notifications.qml
+++ b/services/Notifications.qml
@@ -216,7 +216,7 @@ Singleton {
 
     function cancelTimeout(id) {
         const index = root.list.findIndex((notif) => notif.notificationId === id);
-        if (root.list[index] != null)
+        if (root.list[index] != null && root.list[index].timer != null)
             root.list[index].timer.stop();
     }
 


### PR DESCRIPTION
### Summary
Prevents a `TypeError: Cannot read properties of null (reading 'stop')` when `cancelTimeout()` is called for notifications that do not have an active countdown timer.

### Problem
When notifications are delivered while `popupInhibited` is `true` (e.g. while the right sidebar is open or `silent` mode is active), no `NotifTimer` instance is attached to the notification object. However, calling `cancelTimeout(id)` directly dereferenced `root.list[index].timer.stop()` without checking if `timer` was non-null.

### Changes
- Added a null check for `root.list[index].timer != null` before calling `.stop()`.

### How to test
1. Open the right sidebar (inhibits popup creation).
2. Send a notification: `notify-send "Test" "Hello"`.
3. Close the sidebar and interact with the notification (or trigger any timeout cancellation code path).
4. **Before**: JS TypeError logged when attempting to stop a null timer.
5. **After**: Handled safely with no errors.