### PR TITLE
fix(notifications): guard against undefined action in attemptInvokeAc…

### DIFF
--- a/services/Notifications.qml
+++ b/services/Notifications.qml
@@ -244,7 +244,11 @@ Singleton {
             const notifServerNotif = notifServer.trackedNotifications.values[notifServerIndex];
             const action = notifServerNotif.actions.find((action) => action.identifier === notifIdentifier);
             // console.log("Action found: " + JSON.stringify(action));
-            action.invoke()
+            if (action) {
+                action.invoke();
+            } else {
+                console.warn("[Notifications] Action not found:", notifIdentifier);
+            }
         } 
         else {
             console.log("Notification not found in server: " + id)


### PR DESCRIPTION
### Summary
Guards against a `TypeError` when invoking a notification action if the action identifier cannot be found on the server's tracked notification instance.

### Problem
In `attemptInvokeAction(id, notifIdentifier)`, `actions.find(...)` returns `undefined` if the action identifier does not match any action on `notifServerNotif`. Calling `action.invoke()` directly on an undefined value causes an unhandled JS exception.

### Changes
- Check if `action` is defined before calling `action.invoke()`.
- Added a warning log `console.warn("[Notifications] Action not found:", notifIdentifier)` if the action was not found.

### How to test
1. Send a notification with action buttons: `notify-send -A "test=Click Me" "Action" "Testing"`.
2. Click the action button in the notification popup.
3. If an edge-case ID mismatch or timing race occurs, it now gracefully logs a warning instead of throwing an unhandled exception.