### PR TITLE
fix(notifications): guard JSON.parse against corrupt notification file

### DIFF
--- a/services/Notifications.qml
+++ b/services/Notifications.qml
@@ -268,29 +268,37 @@ Singleton {
         id: notifFileView
         path: Qt.resolvedUrl(filePath)
         onLoaded: {
-            const fileContents = notifFileView.text()
-            root.list = JSON.parse(fileContents).map((notif) => {
-                return notifComponent.createObject(root, {
-                    "notificationId": notif.notificationId,
-                    "actions": [], // Notification actions are meaningless if they're not tracked by the server or the sender is dead
-                    "appIcon": notif.appIcon,
-                    "appName": notif.appName,
-                    "body": notif.body,
-                    "image": notif.image,
-                    "summary": notif.summary,
-                    "time": notif.time,
-                    "urgency": notif.urgency,
+            try {
+                const fileContents = notifFileView.text()
+                root.list = JSON.parse(fileContents).map((notif) => {
+                    return notifComponent.createObject(root, {
+                        "notificationId": notif.notificationId,
+                        "actions": [], // Notification actions are meaningless if they're not tracked by the server or the sender is dead
+                        "appIcon": notif.appIcon,
+                        "appName": notif.appName,
+                        "body": notif.body,
+                        "image": notif.image,
+                        "summary": notif.summary,
+                        "time": notif.time,
+                        "urgency": notif.urgency,
+                    });
                 });
-            });
-            // Find largest notificationId
-            let maxId = 0
-            root.list.forEach((notif) => {
-                maxId = Math.max(maxId, notif.notificationId)
-            })
+                // Find largest notificationId
+                let maxId = 0
+                root.list.forEach((notif) => {
+                    maxId = Math.max(maxId, notif.notificationId)
+                })
 
-            console.log("[Notifications] File loaded")
-            root.idOffset = maxId
-            root.initDone()
+                console.log("[Notifications] File loaded")
+                root.idOffset = maxId
+                root.initDone()
+            } catch (e) {
+                console.error("[Notifications] Failed to parse notifications file, resetting:", e)
+                root.list = []
+                notifFileView.setText(stringifyList(root.list))
+                root.idOffset = 0
+                root.initDone()
+            }
         }
         onLoadFailed: (error) => {
             if(error == FileViewError.FileNotFound) {


### PR DESCRIPTION
### Summary
Wraps the notification storage file parsing logic in a `try/catch` block to prevent crashes if the file contents become corrupted.

### Problem
In `notifFileView.onLoaded`, `JSON.parse(fileContents)` was called without a `try/catch` block. If the JSON file on disk becomes corrupted (e.g. system crash, mid-write cutoff, or invalid manual edit), `onLoadFailed` is not triggered because the file exists. The unhandled exception left `root.list` and `root.idOffset` uninitialized, causing notifications to break entirely.

### Changes
- Wrapped `JSON.parse` and list initialization inside `try/catch`.
- On JSON parse failure, logs an error, resets `root.list = []`, saves the clean state to disk, resets `idOffset = 0`, and calls `root.initDone()`.

### How to test
1. Corrupt the notification storage file: `echo "INVALID_JSON" > ~/.config/quickshell/end4-pC/notifications.json` (or your configured path).
2. Start or reload Quickshell.
3. **Before**: Quickshell logs an uncaught JSON parse error; notifications fail to load or track.
4. **After**: An error is cleanly logged, the file is reinitialized safely, and notifications continue functioning normally.