### PR TITLE
fix(hyprland): add try-catch around hyprctl JSON parsing

### DIFF
--- a/services/HyprlandData.qml
+++ b/services/HyprlandData.qml
@@ -105,14 +105,18 @@ Singleton {
         stdout: StdioCollector {
             id: clientsCollector
             onStreamFinished: {
-                root.windowList = JSON.parse(clientsCollector.text)
-                let tempWinByAddress = {};
-                for (var i = 0; i < root.windowList.length; ++i) {
-                    var win = root.windowList[i];
-                    tempWinByAddress[win.address] = win;
+                try {
+                    root.windowList = JSON.parse(clientsCollector.text);
+                    let tempWinByAddress = {};
+                    for (var i = 0; i < root.windowList.length; ++i) {
+                        var win = root.windowList[i];
+                        tempWinByAddress[win.address] = win;
+                    }
+                    root.windowByAddress = tempWinByAddress;
+                    root.addresses = root.windowList.map(win => win.address);
+                } catch (e) {
+                    console.error("[HyprlandData] Failed to parse clients:", e);
                 }
-                root.windowByAddress = tempWinByAddress;
-                root.addresses = root.windowList.map(win => win.address);
             }
         }
     }
@@ -123,7 +127,11 @@ Singleton {
         stdout: StdioCollector {
             id: monitorsCollector
             onStreamFinished: {
-                root.monitors = JSON.parse(monitorsCollector.text);
+                try {
+                    root.monitors = JSON.parse(monitorsCollector.text);
+                } catch (e) {
+                    console.error("[HyprlandData] Failed to parse monitors:", e);
+                }
             }
         }
     }
@@ -134,7 +142,11 @@ Singleton {
         stdout: StdioCollector {
             id: layersCollector
             onStreamFinished: {
-                root.layers = JSON.parse(layersCollector.text);
+                try {
+                    root.layers = JSON.parse(layersCollector.text);
+                } catch (e) {
+                    console.error("[HyprlandData] Failed to parse layers:", e);
+                }
             }
         }
     }
@@ -145,15 +157,19 @@ Singleton {
         stdout: StdioCollector {
             id: workspacesCollector
             onStreamFinished: {
-                var rawWorkspaces = JSON.parse(workspacesCollector.text);
-                root.workspaces = rawWorkspaces.filter(ws => ws.id >= 1 && ws.id <= 100);
-                let tempWorkspaceById = {};
-                for (var i = 0; i < root.workspaces.length; ++i) {
-                    var ws = root.workspaces[i];
-                    tempWorkspaceById[ws.id] = ws;
+                try {
+                    var rawWorkspaces = JSON.parse(workspacesCollector.text);
+                    root.workspaces = rawWorkspaces.filter(ws => ws.id >= 1 && ws.id <= 100);
+                    let tempWorkspaceById = {};
+                    for (var i = 0; i < root.workspaces.length; ++i) {
+                        var ws = root.workspaces[i];
+                        tempWorkspaceById[ws.id] = ws;
+                    }
+                    root.workspaceById = tempWorkspaceById;
+                    root.workspaceIds = root.workspaces.map(ws => ws.id);
+                } catch (e) {
+                    console.error("[HyprlandData] Failed to parse workspaces:", e);
                 }
-                root.workspaceById = tempWorkspaceById;
-                root.workspaceIds = root.workspaces.map(ws => ws.id);
             }
         }
     }
@@ -164,7 +180,11 @@ Singleton {
         stdout: StdioCollector {
             id: activeWorkspaceCollector
             onStreamFinished: {
-                root.activeWorkspace = JSON.parse(activeWorkspaceCollector.text);
+                try {
+                    root.activeWorkspace = JSON.parse(activeWorkspaceCollector.text);
+                } catch (e) {
+                    console.error("[HyprlandData] Failed to parse active workspace:", e);
+                }
             }
         }
     }


### PR DESCRIPTION
### Summary
Adds defensive `try/catch` blocks around `JSON.parse()` for all `hyprctl -j` collectors in `HyprlandData.qml`.

### Problem
All five `Process` collectors (`getClients`, `getMonitors`, `getLayers`, `getWorkspaces`, `getActiveWorkspace`) parsed CLI outputs with bare `JSON.parse(...)`. If Hyprland IPC is interrupted, restarting, or returns non-JSON error text (e.g. socket unavailable), the unhandled syntax error breaks subsequent handler execution. Other services in the codebase (`Weather.qml`, `KeyringStorage.qml`, `Booru.qml`) already wrap JSON parsing defensively.

### Changes
- Wrapped `JSON.parse` in `getClients`, `getMonitors`, `getLayers`, `getWorkspaces`, and `getActiveWorkspace` inside `try/catch` blocks.
- Added descriptive error logging for troubleshooting without crashing the reactive execution context.

### How to test
- Code refactoring / defensive improvement: verified all collectors continue parsing normal JSON output as expected without affecting reactive bindings.