### PR TITLE
feat(weather): allow configuring OpenWeather API key via keyring

### DIFF
--- a/services/LauncherSearch.qml
+++ b/services/LauncherSearch.qml
@@ -213,6 +213,18 @@ Singleton {
                 Quickshell.execDetached(["notify-send", "Pexels", Translation.tr("API key saved!"), "-a", "Shell"]);
             }
         },
+        {
+            action: "openweather",
+            execute: args => {
+                if (!args || args.trim().length === 0) {
+                    Quickshell.execDetached(["notify-send", "OpenWeather", Translation.tr("Usage: /openweather YOUR_API_KEY"), "-a", "Shell"]);
+                    return;
+                }
+                KeyringStorage.setNestedField(["apiKeys", "openweather"], args.trim());
+                Quickshell.execDetached(["notify-send", "OpenWeather", Translation.tr("API key saved!"), "-a", "Shell"]);
+                Weather.getData();
+            }
+        },
     ]
 
     // Combined built-in and user actions

--- a/services/Weather.qml
+++ b/services/Weather.qml
@@ -93,9 +93,10 @@ Singleton {
     }
 
     function getData() {
-        let apiKey = "8b05d62206f459e1d298cbe5844d7d87"
+        const defaultApiKey = "8b05d62206f459e1d298cbe5844d7d87"
+        let apiKey = KeyringStorage.keyringData?.apiKeys?.openweather || defaultApiKey
 
-        if (apiKey === "") {
+        if (!apiKey || apiKey === "") {
             console.error("[WeatherService] Missing OpenWeather API key.")
             return
         }


### PR DESCRIPTION
### Summary
Allows users to configure their own OpenWeatherMap API key securely via `KeyringStorage` and the launcher (`/openweather YOUR_KEY`), while keeping the default key as a fallback so existing setups continue working seamlessly.

### Problem
The OpenWeather API key was previously hardcoded directly into `Weather.qml` with no user-friendly mechanism to customize it without modifying the source code. Other web integrations in the shell (`unsplash`, `wallhaven`, `pexels`) allow securely saving API keys via keyring and convenient launcher actions.

### Changes
- Updated `Weather.qml` to read from `KeyringStorage.keyringData?.apiKeys?.openweather`, falling back to the existing default key if none is set in the keyring.
- Added `/openweather YOUR_API_KEY` action in `LauncherSearch.qml` matching the existing pattern of `/unsplash`, `/wallhaven`, and `/pexels`.

### How to test
1. Open the launcher (Super key).
2. Type `/openweather YOUR_KEY` and press Enter.
3. Verify the desktop notification: "API key saved!".
4. Verify weather data fetches successfully with the custom key.