### PR TITLE
[FIX FOR ISSUE #129] Add support for DisplayID 2.0 + HF-EEODB for HDR EDID parsing. 

### DIFF
--- a/modules/ii/settings/pages/HyprlandConfig.qml
+++ b/modules/ii/settings/pages/HyprlandConfig.qml
@@ -190,7 +190,7 @@ ContentPage {
                 NoticeBox {
                     Layout.fillWidth: true
                     visible: monitorConfig.monitors[monitorCanvas.selectedIndex]?.hdrSupported === false
-                    text: Translation.tr("This display's EDID does not report HDR support, enabling it below is unlikely to work correctly.")
+                    text: Translation.tr("This display's EDID does not report HDR support, so HDR options are disabled here. Open an issue in GitHub if you think this is a mistake.")
                 }
 
                 GroupedList {

--- a/scripts/hyprland/monitor_caps.py
+++ b/scripts/hyprland/monitor_caps.py
@@ -10,6 +10,11 @@ BPC_CODES = {1: 6, 2: 8, 3: 10, 4: 12, 5: 14, 6: 16}
 # CTA-861 extended data block tags.
 EXT_TAG_HDR_STATIC_METADATA = 0x06
 EXT_TAG_HDR_DYNAMIC_METADATA = 0x14
+EXT_TAG_HF_EEODB = 0x78
+
+# DisplayID 2.0 data block tag that wraps a CTA-861-style data block
+# collection (same tag/length encoding as the legacy CTA-861 extension).
+DISPLAYID_TAG_CTA861 = 0x81
 
 UNKNOWN_CAPS = {"digital": None, "maxBpc": None, "hdr": None, "hdrDynamic": None}
 
@@ -18,6 +23,75 @@ def find_edid_path(output_name):
     # st_size is always 0 for this sysfs attribute, so we can only check hat it exists. An empty read means disconnected.
     matches = glob.glob(f"/sys/class/drm/card*-{output_name}/edid")
     return matches[0] if matches else None
+
+
+def scan_cta_data_blocks(data, start, end):
+    """Walk a CTA-861-style data block collection (1-byte tag/length
+    headers, tag 7 meaning an extended tag follows) between [start, end)
+    and report which HDR-related blocks it contains. Used both for a
+    legacy standalone CTA-861 extension and for the CTA-861 block
+    DisplayID 2.0 nests inside its own data blocks."""
+    hdr = False
+    hdr_dynamic = False
+    pos = start
+    while pos < end and pos < len(data):
+        header = data[pos]
+        tag = header >> 5
+        length = header & 0x1F
+        if tag == 7 and length >= 1 and pos + 1 < len(data):
+            ext_tag = data[pos + 1]
+            if ext_tag == EXT_TAG_HDR_STATIC_METADATA:
+                hdr = True
+            elif ext_tag == EXT_TAG_HDR_DYNAMIC_METADATA:
+                hdr_dynamic = True
+        pos += length + 1
+    return hdr, hdr_dynamic
+
+
+def find_hf_eeodb_count(ext):
+    if len(ext) < 5:
+        return None
+    dtd_offset = ext[2]
+    pos = 4
+    end = min(dtd_offset, len(ext))
+    while pos < end:
+        header = ext[pos]
+        tag = header >> 5
+        length = header & 0x1F
+        if tag == 7 and length == 2 and pos + 2 < len(ext) and ext[pos + 1] == EXT_TAG_HF_EEODB:
+            return ext[pos + 2]
+        pos += length + 1
+    return None
+
+
+def scan_displayid_extension(ext):
+    """DisplayID 2.0 uses its own 3-byte-header data blocks (tag,
+    revision, length), unrelated to CTA-861's 1-byte header. Newer
+    panels report HDR support by nesting a full CTA-861-style block
+    collection inside one of these, tagged 0x81, instead of exposing a
+    standalone CTA-861 extension at all."""
+    hdr = False
+    hdr_dynamic = False
+    if len(ext) < 5:
+        return hdr, hdr_dynamic
+
+    section_bytes = ext[2]
+    pos = 5
+    end = min(5 + section_bytes, len(ext))
+    while pos + 3 <= end:
+        tag = ext[pos]
+        length = ext[pos + 2]
+        payload_start = pos + 3
+        payload_end = payload_start + length
+        if payload_end > len(ext):
+            break
+        if tag == DISPLAYID_TAG_CTA861:
+            block_hdr, block_hdr_dynamic = scan_cta_data_blocks(ext, payload_start, payload_end)
+            hdr = hdr or block_hdr
+            hdr_dynamic = hdr_dynamic or block_hdr_dynamic
+        pos = payload_end
+
+    return hdr, hdr_dynamic
 
 
 def parse_edid(data):
@@ -33,25 +107,39 @@ def parse_edid(data):
         caps["maxBpc"] = BPC_CODES.get(bpc_code)
 
     n_ext = data[126]
+
     for i in range(n_ext):
         start = 128 + 128 * i
         ext = data[start:start + 128]
-        if len(ext) < 5 or ext[0] != 0x02:
-            continue  # not a CTA-861 extension block
+        if len(ext) >= 5 and ext[0] == 0x02:
+            real_count = find_hf_eeodb_count(ext)
+            if real_count is not None and real_count > n_ext:
+                n_ext = real_count
+            break
 
-        dtd_offset = ext[2]
-        pos = 4
-        while pos < dtd_offset and pos < len(ext):
-            header = ext[pos]
-            tag = header >> 5
-            length = header & 0x1F
-            if tag == 7 and length >= 1 and pos + 1 < len(ext):
-                ext_tag = ext[pos + 1]
-                if ext_tag == EXT_TAG_HDR_STATIC_METADATA:
-                    caps["hdr"] = True
-                elif ext_tag == EXT_TAG_HDR_DYNAMIC_METADATA:
-                    caps["hdrDynamic"] = True
-            pos += length + 1
+    truncated = len(data) < 128 + 128 * n_ext
+
+    for i in range(n_ext):
+        start = 128 + 128 * i
+        ext = data[start:start + 128]
+        if len(ext) < 5:
+            continue
+
+        if ext[0] == 0x02:
+            dtd_offset = ext[2]
+            hdr, hdr_dynamic = scan_cta_data_blocks(ext, 4, min(dtd_offset, len(ext)))
+        elif ext[0] == 0x70:
+            hdr, hdr_dynamic = scan_displayid_extension(ext)
+        else:
+            continue
+
+        caps["hdr"] = caps["hdr"] or hdr
+        caps["hdrDynamic"] = caps["hdrDynamic"] or hdr_dynamic
+
+    if truncated and not caps["hdr"]:
+        caps["hdr"] = None
+    if truncated and not caps["hdrDynamic"]:
+        caps["hdrDynamic"] = None
 
     return caps
 

--- a/scripts/hyprland/monitor_configurator.py
+++ b/scripts/hyprland/monitor_configurator.py
@@ -9,6 +9,8 @@ STRING_KEYS = {"output", "mode", "position", "cm", "mirror"}
 BOOL_KEYS = {"disabled"}
 FIELD_RE = re.compile(r'^(\s*)([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*,?\s*(--.*)?$')
 OUTPUT_RE = re.compile(r'output\s*=\s*"([^"]*)"')
+SINGLE_LINE_RE = re.compile(r'hl\.monitor\(\{\s*(.*?)\s*\}\)\s*$')
+FIELD_ITEM_RE = re.compile(r'([A-Za-z_][A-Za-z0-9_]*)\s*=\s*("(?:[^"\\]|\\.)*"|[^,]+)')
 
 
 def to_lua_value(key, value):
@@ -94,6 +96,20 @@ def split_blocks(lines):
     return segments
 
 
+def split_single_line_fields(line):
+    """A block written entirely on one line (header, fields, and closing
+    paren all together) has no separate header/footer lines to anchor on.
+    Pull its fields out so it can be normalized into the same multi-line
+    shape every other block uses."""
+    m = SINGLE_LINE_RE.search(line)
+    if not m:
+        return []
+    fields = []
+    for fm in FIELD_ITEM_RE.finditer(m.group(1)):
+        fields.append((fm.group(1), fm.group(2).strip()))
+    return fields
+
+
 def rebuild_field_line(m, key, value):
     indent, comment = m.group(1), m.group(4)
     line = f"{indent}{key} = {value},"
@@ -103,9 +119,15 @@ def rebuild_field_line(m, key, value):
 
 
 def edit_block_lines(block_lines, set_dict, reset_keys):
-    header = block_lines[0]
-    footer = block_lines[-1]
-    body = block_lines[1:-1]
+    if len(block_lines) == 1:
+        fields = split_single_line_fields(block_lines[0])
+        header = "hl.monitor({\n"
+        footer = "})\n"
+        body = [f'    {k} = {v},\n' for k, v in fields]
+    else:
+        header = block_lines[0]
+        footer = block_lines[-1]
+        body = block_lines[1:-1]
 
     default_indent = "    "
     for line in body:


### PR DESCRIPTION
# Fix for #129 
Adds DisplayID 2.0 and HF-EEODB support to the HDR parser, which checks if a monitor reports as HDR capable. Also fixes a bug where a single lined monitors.lua would corrupt itself by repeating itself over and over.